### PR TITLE
cont: refactor: Create tests for identifying multiline-comments with …

### DIFF
--- a/tests/regex_multiline_block_comments.py
+++ b/tests/regex_multiline_block_comments.py
@@ -1,0 +1,158 @@
+﻿# -*- coding: utf-8 -*-
+'''
+Created on: Sun, 2024-01-21 (22:14:48)
+
+@author: Matthias Kader
+
+
+Test zu Issue #6 and #2:
+
+Referenzenierungen innerhalb von Multiline-Comments dürfen nicht als solche gewertet werden!
+
+
+'''
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+import re
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+class Procedure:
+    """
+    ### ACHTUNG: Nachbau - nur von den relevanten zu testzwecken erforderlichen Inhalten der Klasse. Diese sind z.T. modifizeirt ohne weiteren Kommentar!!
+    """
+
+
+    @classmethod
+    def initialize_input_code(cls, input_path:str):
+        """
+        Liesst den zu analysierenden und zu dokumentierenden Input-Quellcode ein und speichert ihn innerhalb dder Superklasse als immer verfuegbare Liste einzelner Zeileninhalte ab.
+
+        ### TODO: Später sollte hier auch noch eine einfache GUI erstellt werden zur Auswahl!
+        ggf. sollte diese GUI aber losgelöst von dieser Klasse sein (Wiederholfunktion!). Daher als Kapselung mit übergebenen input-path!
+        """
+
+        with open(input_path, "r") as file:
+
+            cls.raw_source_code_str = file.read()
+
+
+
+        cls.raw_source_code_list = cls.raw_source_code_str.split("\n")
+
+
+
+
+
+
+
+
+
+
+
+
+
+def find_lines_with_blockcomment(text:str) -> list[int]:
+
+
+    pattern = re.compile(r'(""".*?""")|(\'\'\'.*?\'\'\')', re.DOTALL)
+
+    matches = pattern.findall(text)
+
+
+    comments = [match[0] or match[1] for match in matches]
+    return comments
+
+
+
+    pass
+
+
+
+
+
+
+
+def find_multiline_comment(code):
+    pattern = re.compile(r'(""".*?""")|(\'\'\'.*?\'\'\')', re.DOTALL)
+    matches = pattern.finditer(code)
+    
+    comments = []
+    for match in matches:
+        comment = match.group(0)
+        start_line = code.count('\n', 0, match.start()) + 1
+        end_line = code.count('\n', 0, match.end()) + 1
+        comments.append((start_line, end_line, comment))
+    
+    return comments
+
+
+
+
+
+
+
+Procedure.initialize_input_code("tests/regex_multiline_block_comments_beispieltext.py")
+
+
+print(Procedure.raw_source_code_str)
+
+
+
+
+
+
+
+lines_block = find_lines_with_blockcomment(Procedure.raw_source_code_str)
+
+
+multiline_comments = find_multiline_comment(Procedure.raw_source_code_str)
+
+for start_line, end_line, comment in multiline_comments:
+    print(f"Found comment starting at line {start_line} and ending at line {end_line}:\n{comment}\n")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+print("ende")
+
+
+

--- a/tests/regex_multiline_block_comments_beispieltext.py
+++ b/tests/regex_multiline_block_comments_beispieltext.py
@@ -1,0 +1,49 @@
+﻿'''
+Beispielcode für Python zur Durchsuche miitels Regex...
+'''
+
+
+
+
+
+
+def test():
+    """
+    Hier steht ein Docstring zur Funktion Test
+    Hier auch noch.
+    Ruft keine Weitere Funktion auf.
+    """
+    a = "Hello World"
+    print(a)
+    return a
+
+
+
+
+def test_main():
+    """
+    Hier der Docstring zur MAin-Test-Function.
+    Ruft die methode test() auf durch folgende Zeile:
+        print(test())
+    Dies darf nicht als Referenzierung gewertet werden...
+    """
+    print(test())
+
+
+
+
+
+
+def anderer_test_main():
+    '''
+    Hier der Docstring zur MAin-Test-Function.
+    Ruft die methode test() auf durch folgende Zeile:
+        print(test())
+    Dies darf nicht als Referenzierung gewertet werden...
+    '''
+    print(test())
+
+
+
+
+


### PR DESCRIPTION
…their line numbers

Important to know where multiline-comments are as they have to be unconsidered for analyses of references - this counts for python, c++ e.g. not for VBA as there are no multiline-comments (or at least no extra symbol or keyword for those).