### PR TITLE
Replace triple backticks with single backticks

### DIFF
--- a/code_documenter.py
+++ b/code_documenter.py
@@ -1391,15 +1391,15 @@ class Procedure():
         # proc_name:str, line_no:str, line_text:str
     
 
-        # replacer_placeholder_reference = "\n" * 3 + f"- [```{target_procedure_name}```](#{target_procedure_name}) <small> : [Zeile {line_no_reference}] : ```{line_code}``` </small>".replace(line_code, line_code.rstrip("\n")) + "\n"
+        # replacer_placeholder_reference = "\n" * 3 + f"- [`{target_procedure_name}`](#{target_procedure_name}) <small> : [Zeile {line_no_reference}] : `{line_code}` </small>".replace(line_code, line_code.rstrip("\n")) + "\n"
         
         if line_text == "":
             __optional_code_line = ""
         else:
-            __optional_code_line = f": ```{line_text}```"
+            __optional_code_line = f": `{line_text}`"
 
 
-        markdown_entry = f"- [```{proc_name}```](#{proc_name}) : <small>  [Zeile {line_no}] {__optional_code_line} </small>"
+        markdown_entry = f"- [`{proc_name}`](#{proc_name}) : <small>  [Zeile {line_no}] {__optional_code_line} </small>"
 
         markdown_entry = markdown_entry.replace(line_text, line_text.rstrip("\n")) 
         
@@ -1702,7 +1702,7 @@ class Procedure():
                 # OBSOLET: wird in Methode get_markdown_for_code_line_of_call_entry erledigt
                 # line_code:str = line_code.rstrip("\n")
 
-                # replacer_placeholder_reference = f"* [```{calling_procedure_name}```](#{calling_procedure_name}) : <small>  [Zeile {line_no}] : ```{line_code}``` </small>"
+                # replacer_placeholder_reference = f"* [`{calling_procedure_name}`](#{calling_procedure_name}) : <small>  [Zeile {line_no}] : `{line_code}` </small>"
 
 
                 replacer_placeholder_reference = self.get_markdown_for_code_line_of_call_entry(calling_procedure_name, line_no, line_code)
@@ -1710,7 +1710,7 @@ class Procedure():
 
 
                 # # AUSBLICK: weitere collapse details : funktioniert technisch, allerdings steht das collapsable immer in neuer Zeile und daher wird es groß - vielleicht später in schön machen...
-                # __replacer_placeholder_reference = f"*   [```{calling_procedure_name}```](#{calling_procedure_name})  <details> <summary>: <small>Zeile {line_no}</small> </summary> ```{line_code}``` </details>"
+                # __replacer_placeholder_reference = f"*   [`{calling_procedure_name}`](#{calling_procedure_name})  <details> <summary>: <small>Zeile {line_no}</small> </summary> `{line_code}` </details>"
 
 
 

--- a/html/code_documenter.html
+++ b/html/code_documenter.html
@@ -787,7 +787,7 @@ class Procedure():
             # TODO: Vorgehen wenn es KEINE instanz gibt???! - sollte kein Problem sein, dadurch dass nach jedem Einfügen immer wieder der Ausgangszustand bzgl. des Platzhalters wiederhergestellt wird un dieser am Ende gelöscht wird??!
 
             # Aufbau des Markdown.-Codes fuer diesen TOC-Eintrag:
-            new_entry = &#34;* [```{temp_prozedur_name}```](#{temp_prozedur_name}) &lt;small&gt;(Zeile {temp_prozedur_zeile})&lt;/small&gt;&#34;.format(temp_prozedur_name=prozedur_name, temp_prozedur_zeile=prozedur_initialisierungszeile)
+            new_entry = &#34;* [`{temp_prozedur_name}`](#{temp_prozedur_name}) &lt;small&gt;(Zeile {temp_prozedur_zeile})&lt;/small&gt;&#34;.format(temp_prozedur_name=prozedur_name, temp_prozedur_zeile=prozedur_initialisierungszeile)
 
             # Append the placeholder to have this flag for insert further entries:
             new_entry = new_entry + &#34;\n  &#34; + platzhalter
@@ -1174,8 +1174,8 @@ class Procedure():
 
 
 
-                replacer_placeholder_reference = f&#34;&lt;small&gt;  Zeile {line_no_reference} &lt;/small&gt; : ```{line_code}``` ODER: {target_procedure_name}&#34;
-                # replacer_placeholder_reference = f&#34;* [```{code}```](#{target_procedure}) : &lt;small&gt;  Zeile {line_no_reference} : ```{line_code}``` &lt;/small&gt;&#34;
+                replacer_placeholder_reference = f&#34;&lt;small&gt;  Zeile {line_no_reference} &lt;/small&gt; : `{line_code}` ODER: {target_procedure_name}&#34;
+                # replacer_placeholder_reference = f&#34;* [`{code}`](#{target_procedure}) : &lt;small&gt;  Zeile {line_no_reference} : `{line_code}` &lt;/small&gt;&#34;
 
                 replacer_placeholder_reference = replacer_placeholder_reference  + f&#34;\n{_PLACEHOLDER_REFERENCE}&#34;
                     
@@ -1240,11 +1240,11 @@ class Procedure():
                 # Um MArkdown nicht zu zerschiessen muss der letzte Zeilenumbruch des line_codes entfernt werrden:
                 line_code:str = line_code.rstrip(&#34;\n&#34;)
 
-                replacer_placeholder_reference = f&#34;* [```{calling_procedure_name}```](#{calling_procedure_name}) : &lt;small&gt;  Zeile {line_no} : ```{line_code}``` &lt;/small&gt;&#34;
+                replacer_placeholder_reference = f&#34;* [`{calling_procedure_name}`](#{calling_procedure_name}) : &lt;small&gt;  Zeile {line_no} : `{line_code}` &lt;/small&gt;&#34;
 
 
                 # # AUSBLICK: weitere collapse details : funktioniert technisch, allerdings steht das collapsable immer in neuer Zeile und daher wird es groß - vielleicht später in schön machen...
-                # __replacer_placeholder_reference = f&#34;*   [```{calling_procedure_name}```](#{calling_procedure_name})  &lt;details&gt; &lt;summary&gt;: &lt;small&gt;Zeile {line_no}&lt;/small&gt; &lt;/summary&gt; ```{line_code}``` &lt;/details&gt;&#34;
+                # __replacer_placeholder_reference = f&#34;*   [`{calling_procedure_name}`](#{calling_procedure_name})  &lt;details&gt; &lt;summary&gt;: &lt;small&gt;Zeile {line_no}&lt;/small&gt; &lt;/summary&gt; `{line_code}` &lt;/details&gt;&#34;
 
 
 
@@ -1370,11 +1370,11 @@ class Procedure():
                             # Um MArkdown nicht zu zerschiessen muss der letzte Zeilenumbruch des line_codes entfernt werrden:
                             line_code:str = line_code.rstrip(&#34;\n&#34;)
 
-                            replacer_placeholder_reference = f&#34;* [```{calling_procedure_name}```](#{calling_procedure_name}) : &lt;small&gt;  Zeile {line_no} : ```{line_code}``` &lt;/small&gt;&#34;
+                            replacer_placeholder_reference = f&#34;* [`{calling_procedure_name}`](#{calling_procedure_name}) : &lt;small&gt;  Zeile {line_no} : `{line_code}` &lt;/small&gt;&#34;
 
 
                             # # AUSBLICK: weitere collapse details : funktioniert technisch, allerdings steht das collapsable immer in neuer Zeile und daher wird es groß - vielleicht später in schön machen...
-                            # __replacer_placeholder_reference = f&#34;*   [```{calling_procedure_name}```](#{calling_procedure_name})  &lt;details&gt; &lt;summary&gt;: &lt;small&gt;Zeile {line_no}&lt;/small&gt; &lt;/summary&gt; ```{line_code}``` &lt;/details&gt;&#34;
+                            # __replacer_placeholder_reference = f&#34;*   [`{calling_procedure_name}`](#{calling_procedure_name})  &lt;details&gt; &lt;summary&gt;: &lt;small&gt;Zeile {line_no}&lt;/small&gt; &lt;/summary&gt; `{line_code}` &lt;/details&gt;&#34;
 
 
 
@@ -3336,7 +3336,7 @@ Prozedur gehoeren.</dd>
             # TODO: Vorgehen wenn es KEINE instanz gibt???! - sollte kein Problem sein, dadurch dass nach jedem Einfügen immer wieder der Ausgangszustand bzgl. des Platzhalters wiederhergestellt wird un dieser am Ende gelöscht wird??!
 
             # Aufbau des Markdown.-Codes fuer diesen TOC-Eintrag:
-            new_entry = &#34;* [```{temp_prozedur_name}```](#{temp_prozedur_name}) &lt;small&gt;(Zeile {temp_prozedur_zeile})&lt;/small&gt;&#34;.format(temp_prozedur_name=prozedur_name, temp_prozedur_zeile=prozedur_initialisierungszeile)
+            new_entry = &#34;* [`{temp_prozedur_name}`](#{temp_prozedur_name}) &lt;small&gt;(Zeile {temp_prozedur_zeile})&lt;/small&gt;&#34;.format(temp_prozedur_name=prozedur_name, temp_prozedur_zeile=prozedur_initialisierungszeile)
 
             # Append the placeholder to have this flag for insert further entries:
             new_entry = new_entry + &#34;\n  &#34; + platzhalter
@@ -3723,8 +3723,8 @@ Prozedur gehoeren.</dd>
 
 
 
-                replacer_placeholder_reference = f&#34;&lt;small&gt;  Zeile {line_no_reference} &lt;/small&gt; : ```{line_code}``` ODER: {target_procedure_name}&#34;
-                # replacer_placeholder_reference = f&#34;* [```{code}```](#{target_procedure}) : &lt;small&gt;  Zeile {line_no_reference} : ```{line_code}``` &lt;/small&gt;&#34;
+                replacer_placeholder_reference = f&#34;&lt;small&gt;  Zeile {line_no_reference} &lt;/small&gt; : `{line_code}` ODER: {target_procedure_name}&#34;
+                # replacer_placeholder_reference = f&#34;* [`{code}`](#{target_procedure}) : &lt;small&gt;  Zeile {line_no_reference} : `{line_code}` &lt;/small&gt;&#34;
 
                 replacer_placeholder_reference = replacer_placeholder_reference  + f&#34;\n{_PLACEHOLDER_REFERENCE}&#34;
                     
@@ -3789,11 +3789,11 @@ Prozedur gehoeren.</dd>
                 # Um MArkdown nicht zu zerschiessen muss der letzte Zeilenumbruch des line_codes entfernt werrden:
                 line_code:str = line_code.rstrip(&#34;\n&#34;)
 
-                replacer_placeholder_reference = f&#34;* [```{calling_procedure_name}```](#{calling_procedure_name}) : &lt;small&gt;  Zeile {line_no} : ```{line_code}``` &lt;/small&gt;&#34;
+                replacer_placeholder_reference = f&#34;* [`{calling_procedure_name}`](#{calling_procedure_name}) : &lt;small&gt;  Zeile {line_no} : `{line_code}` &lt;/small&gt;&#34;
 
 
                 # # AUSBLICK: weitere collapse details : funktioniert technisch, allerdings steht das collapsable immer in neuer Zeile und daher wird es groß - vielleicht später in schön machen...
-                # __replacer_placeholder_reference = f&#34;*   [```{calling_procedure_name}```](#{calling_procedure_name})  &lt;details&gt; &lt;summary&gt;: &lt;small&gt;Zeile {line_no}&lt;/small&gt; &lt;/summary&gt; ```{line_code}``` &lt;/details&gt;&#34;
+                # __replacer_placeholder_reference = f&#34;*   [`{calling_procedure_name}`](#{calling_procedure_name})  &lt;details&gt; &lt;summary&gt;: &lt;small&gt;Zeile {line_no}&lt;/small&gt; &lt;/summary&gt; `{line_code}` &lt;/details&gt;&#34;
 
 
 
@@ -3919,11 +3919,11 @@ Prozedur gehoeren.</dd>
                             # Um MArkdown nicht zu zerschiessen muss der letzte Zeilenumbruch des line_codes entfernt werrden:
                             line_code:str = line_code.rstrip(&#34;\n&#34;)
 
-                            replacer_placeholder_reference = f&#34;* [```{calling_procedure_name}```](#{calling_procedure_name}) : &lt;small&gt;  Zeile {line_no} : ```{line_code}``` &lt;/small&gt;&#34;
+                            replacer_placeholder_reference = f&#34;* [`{calling_procedure_name}`](#{calling_procedure_name}) : &lt;small&gt;  Zeile {line_no} : `{line_code}` &lt;/small&gt;&#34;
 
 
                             # # AUSBLICK: weitere collapse details : funktioniert technisch, allerdings steht das collapsable immer in neuer Zeile und daher wird es groß - vielleicht später in schön machen...
-                            # __replacer_placeholder_reference = f&#34;*   [```{calling_procedure_name}```](#{calling_procedure_name})  &lt;details&gt; &lt;summary&gt;: &lt;small&gt;Zeile {line_no}&lt;/small&gt; &lt;/summary&gt; ```{line_code}``` &lt;/details&gt;&#34;
+                            # __replacer_placeholder_reference = f&#34;*   [`{calling_procedure_name}`](#{calling_procedure_name})  &lt;details&gt; &lt;summary&gt;: &lt;small&gt;Zeile {line_no}&lt;/small&gt; &lt;/summary&gt; `{line_code}` &lt;/details&gt;&#34;
 
 
 
@@ -4778,7 +4778,7 @@ def generate_toc_entries(cls, subklasse):
         # TODO: Vorgehen wenn es KEINE instanz gibt???! - sollte kein Problem sein, dadurch dass nach jedem Einfügen immer wieder der Ausgangszustand bzgl. des Platzhalters wiederhergestellt wird un dieser am Ende gelöscht wird??!
 
         # Aufbau des Markdown.-Codes fuer diesen TOC-Eintrag:
-        new_entry = &#34;* [```{temp_prozedur_name}```](#{temp_prozedur_name}) &lt;small&gt;(Zeile {temp_prozedur_zeile})&lt;/small&gt;&#34;.format(temp_prozedur_name=prozedur_name, temp_prozedur_zeile=prozedur_initialisierungszeile)
+        new_entry = &#34;* [`{temp_prozedur_name}`](#{temp_prozedur_name}) &lt;small&gt;(Zeile {temp_prozedur_zeile})&lt;/small&gt;&#34;.format(temp_prozedur_name=prozedur_name, temp_prozedur_zeile=prozedur_initialisierungszeile)
 
         # Append the placeholder to have this flag for insert further entries:
         new_entry = new_entry + &#34;\n  &#34; + platzhalter
@@ -5240,11 +5240,11 @@ def write_to_file(cls, output_file_path:str):
                         # Um MArkdown nicht zu zerschiessen muss der letzte Zeilenumbruch des line_codes entfernt werrden:
                         line_code:str = line_code.rstrip(&#34;\n&#34;)
 
-                        replacer_placeholder_reference = f&#34;* [```{calling_procedure_name}```](#{calling_procedure_name}) : &lt;small&gt;  Zeile {line_no} : ```{line_code}``` &lt;/small&gt;&#34;
+                        replacer_placeholder_reference = f&#34;* [`{calling_procedure_name}`](#{calling_procedure_name}) : &lt;small&gt;  Zeile {line_no} : `{line_code}` &lt;/small&gt;&#34;
 
 
                         # # AUSBLICK: weitere collapse details : funktioniert technisch, allerdings steht das collapsable immer in neuer Zeile und daher wird es groß - vielleicht später in schön machen...
-                        # __replacer_placeholder_reference = f&#34;*   [```{calling_procedure_name}```](#{calling_procedure_name})  &lt;details&gt; &lt;summary&gt;: &lt;small&gt;Zeile {line_no}&lt;/small&gt; &lt;/summary&gt; ```{line_code}``` &lt;/details&gt;&#34;
+                        # __replacer_placeholder_reference = f&#34;*   [`{calling_procedure_name}`](#{calling_procedure_name})  &lt;details&gt; &lt;summary&gt;: &lt;small&gt;Zeile {line_no}&lt;/small&gt; &lt;/summary&gt; `{line_code}` &lt;/details&gt;&#34;
 
 
 
@@ -5638,8 +5638,8 @@ Speichert das Ergebnis in der bereits existierenden Objektvariable procedure_obj
 
 
 
-            replacer_placeholder_reference = f&#34;&lt;small&gt;  Zeile {line_no_reference} &lt;/small&gt; : ```{line_code}``` ODER: {target_procedure_name}&#34;
-            # replacer_placeholder_reference = f&#34;* [```{code}```](#{target_procedure}) : &lt;small&gt;  Zeile {line_no_reference} : ```{line_code}``` &lt;/small&gt;&#34;
+            replacer_placeholder_reference = f&#34;&lt;small&gt;  Zeile {line_no_reference} &lt;/small&gt; : `{line_code}` ODER: {target_procedure_name}&#34;
+            # replacer_placeholder_reference = f&#34;* [`{code}`](#{target_procedure}) : &lt;small&gt;  Zeile {line_no_reference} : `{line_code}` &lt;/small&gt;&#34;
 
             replacer_placeholder_reference = replacer_placeholder_reference  + f&#34;\n{_PLACEHOLDER_REFERENCE}&#34;
                 
@@ -5744,11 +5744,11 @@ Speichert das Ergebnis in der bereits existierenden Objektvariable procedure_obj
             # Um MArkdown nicht zu zerschiessen muss der letzte Zeilenumbruch des line_codes entfernt werrden:
             line_code:str = line_code.rstrip(&#34;\n&#34;)
 
-            replacer_placeholder_reference = f&#34;* [```{calling_procedure_name}```](#{calling_procedure_name}) : &lt;small&gt;  Zeile {line_no} : ```{line_code}``` &lt;/small&gt;&#34;
+            replacer_placeholder_reference = f&#34;* [`{calling_procedure_name}`](#{calling_procedure_name}) : &lt;small&gt;  Zeile {line_no} : `{line_code}` &lt;/small&gt;&#34;
 
 
             # # AUSBLICK: weitere collapse details : funktioniert technisch, allerdings steht das collapsable immer in neuer Zeile und daher wird es groß - vielleicht später in schön machen...
-            # __replacer_placeholder_reference = f&#34;*   [```{calling_procedure_name}```](#{calling_procedure_name})  &lt;details&gt; &lt;summary&gt;: &lt;small&gt;Zeile {line_no}&lt;/small&gt; &lt;/summary&gt; ```{line_code}``` &lt;/details&gt;&#34;
+            # __replacer_placeholder_reference = f&#34;*   [`{calling_procedure_name}`](#{calling_procedure_name})  &lt;details&gt; &lt;summary&gt;: &lt;small&gt;Zeile {line_no}&lt;/small&gt; &lt;/summary&gt; `{line_code}` &lt;/details&gt;&#34;
 
 
 

--- a/input_data/beispiel_modul_rekursiv.bas - Dokumentation.html
+++ b/input_data/beispiel_modul_rekursiv.bas - Dokumentation.html
@@ -154,28 +154,28 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 141] : ```    call liebherr``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 141] : `    call liebherr` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 142] : ```    call liebherr ' Aufruf``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 142] : `    call liebherr ' Aufruf` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 144] : ```    call liebherr("ERROR") ' Aufruf waere zwar ungültig, aber Prozedur könnte ja anders aussehen!``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 144] : `    call liebherr("ERROR") ' Aufruf waere zwar ungültig, aber Prozedur könnte ja anders aussehen!` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 148] : ```    var = liebherr("gvkil")``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 148] : `    var = liebherr("gvkil")` </small>
 
 
 
@@ -208,7 +208,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Public Sub bauer()
 ' Anzahl der Referenzierungen im Modul: 0
 ' Anzahl weiterer internen Aufrufe : 5
@@ -234,7 +234,7 @@ Public Sub bauer()
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -341,7 +341,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
    Sub casio()
     ' Anzahl der Referenzierungen im Modul: 0
     ' Anzahl weiterer internen Aufrufe : 0
@@ -353,7 +353,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -404,21 +404,21 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```rekursiv```](#rekursiv) : <small>  [Zeile 55] : ```    call liebherr``` </small>
+- [`rekursiv`](#rekursiv) : <small>  [Zeile 55] : `    call liebherr` </small>
 
-- [```rekursiv```](#rekursiv) : <small>  [Zeile 57] : ```    call liebherr("nochmal")``` </small>
+- [`rekursiv`](#rekursiv) : <small>  [Zeile 57] : `    call liebherr("nochmal")` </small>
 
-- [```main```](#main) : <small>  [Zeile 117] : ```    call liebherr("vor rekursivem Aufruf")``` </small>
+- [`main`](#main) : <small>  [Zeile 117] : `    call liebherr("vor rekursivem Aufruf")` </small>
 
-- [```main```](#main) : <small>  [Zeile 121] : ```    call liebherr("NACH rekursivem Aufruf")``` </small>
+- [`main`](#main) : <small>  [Zeile 121] : `    call liebherr("NACH rekursivem Aufruf")` </small>
 
-- [```bauer```](#bauer) : <small>  [Zeile 141] : ```    call liebherr``` </small>
+- [`bauer`](#bauer) : <small>  [Zeile 141] : `    call liebherr` </small>
 
-- [```bauer```](#bauer) : <small>  [Zeile 142] : ```    call liebherr ' Aufruf``` </small>
+- [`bauer`](#bauer) : <small>  [Zeile 142] : `    call liebherr ' Aufruf` </small>
 
-- [```bauer```](#bauer) : <small>  [Zeile 144] : ```    call liebherr("ERROR") ' Aufruf waere zwar ungültig, aber Prozedur könnte ja anders aussehen!``` </small>
+- [`bauer`](#bauer) : <small>  [Zeile 144] : `    call liebherr("ERROR") ' Aufruf waere zwar ungültig, aber Prozedur könnte ja anders aussehen!` </small>
 
-- [```bauer```](#bauer) : <small>  [Zeile 148] : ```    var = liebherr("gvkil")``` </small>
+- [`bauer`](#bauer) : <small>  [Zeile 148] : `    var = liebherr("gvkil")` </small>
 
 
 
@@ -476,7 +476,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
    Sub liebherr()
    ' Anzahl der Referenzierungen im Modul: 6
     ' Anzahl weiterer internen Aufrufe : 0
@@ -489,7 +489,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -578,17 +578,17 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```addieren```](#addieren) : <small>  [Zeile 111] : ```        wert = addieren(i, i)``` </small>
+- [`addieren`](#addieren) : <small>  [Zeile 111] : `        wert = addieren(i, i)` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```subtrahieren```](#subtrahieren) : <small>  [Zeile 112] : ```        wert = subtrahieren(i, i - 1) ' Erklärung siehe @ Func!``` </small>
+- [`subtrahieren`](#subtrahieren) : <small>  [Zeile 112] : `        wert = subtrahieren(i, i - 1) ' Erklärung siehe @ Func!` </small>
 
 
-  - [```addieren```](#addieren) : <small>  [Zeile 77] : ```    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben``` </small>
+  - [`addieren`](#addieren) : <small>  [Zeile 77] : `    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben` </small>
 
 
 
@@ -599,36 +599,36 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 117] : ```    call liebherr("vor rekursivem Aufruf")``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 117] : `    call liebherr("vor rekursivem Aufruf")` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```rekursiv```](#rekursiv) : <small>  [Zeile 119] : ```    call rekursiv``` </small>
+- [`rekursiv`](#rekursiv) : <small>  [Zeile 119] : `    call rekursiv` </small>
 
 
-  - [```addieren```](#addieren) : <small>  [Zeile 46] : ```    tx = tx + string(addieren(1,2))``` </small>
+  - [`addieren`](#addieren) : <small>  [Zeile 46] : `    tx = tx + string(addieren(1,2))` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```rekursiv```](#rekursiv) : <small>  [Zeile 50] : ```        rekursiv(tx)``` </small>
+  - [`rekursiv`](#rekursiv) : <small>  [Zeile 50] : `        rekursiv(tx)` </small>
 
 
     - <small> *... recursivly calls itself under certain conditions ...* </small> 
 
 
-  - [```liebherr```](#liebherr) : <small>  [Zeile 55] : ```    call liebherr``` </small>
+  - [`liebherr`](#liebherr) : <small>  [Zeile 55] : `    call liebherr` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-  - [```liebherr```](#liebherr) : <small>  [Zeile 57] : ```    call liebherr("nochmal")``` </small>
+  - [`liebherr`](#liebherr) : <small>  [Zeile 57] : `    call liebherr("nochmal")` </small>
 
 
 
@@ -639,7 +639,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 121] : ```    call liebherr("NACH rekursivem Aufruf")``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 121] : `    call liebherr("NACH rekursivem Aufruf")` </small>
 
 
 
@@ -672,7 +672,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Sub main()
 ' Anzahl der Referenzierungen im Modul: 0
 ' Anzahl weiterer internen Aufrufe : 5
@@ -712,7 +712,7 @@ Private Sub main()
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -772,11 +772,11 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```rekursiv```](#rekursiv) : <small>  [Zeile 46] : ```    tx = tx + string(addieren(1,2))``` </small>
+- [`rekursiv`](#rekursiv) : <small>  [Zeile 46] : `    tx = tx + string(addieren(1,2))` </small>
 
-- [```subtrahieren```](#subtrahieren) : <small>  [Zeile 77] : ```    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben``` </small>
+- [`subtrahieren`](#subtrahieren) : <small>  [Zeile 77] : `    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben` </small>
 
-- [```main```](#main) : <small>  [Zeile 111] : ```        wert = addieren(i, i)``` </small>
+- [`main`](#main) : <small>  [Zeile 111] : `        wert = addieren(i, i)` </small>
 
 
 
@@ -834,7 +834,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function addieren(a as integer, b as integer) as integer
 ' Anzahl der Referenzierungen im Modul: 2
 ' Anzahl weiterer internen Aufrufe : 0
@@ -849,7 +849,7 @@ Private Function addieren(a as integer, b as integer) as integer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -904,9 +904,9 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```rekursiv```](#rekursiv) : <small>  [Zeile 50] : ```        rekursiv(tx)``` </small>
+- [`rekursiv`](#rekursiv) : <small>  [Zeile 50] : `        rekursiv(tx)` </small>
 
-- [```main```](#main) : <small>  [Zeile 119] : ```    call rekursiv``` </small>
+- [`main`](#main) : <small>  [Zeile 119] : `    call rekursiv` </small>
 
 
 
@@ -938,26 +938,26 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```addieren```](#addieren) : <small>  [Zeile 46] : ```    tx = tx + string(addieren(1,2))``` </small>
+- [`addieren`](#addieren) : <small>  [Zeile 46] : `    tx = tx + string(addieren(1,2))` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```rekursiv```](#rekursiv) : <small>  [Zeile 50] : ```        rekursiv(tx)``` </small>
+- [`rekursiv`](#rekursiv) : <small>  [Zeile 50] : `        rekursiv(tx)` </small>
 
 
   - <small> *... recursivly calls itself under certain conditions ...* </small> 
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 55] : ```    call liebherr``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 55] : `    call liebherr` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 57] : ```    call liebherr("nochmal")``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 57] : `    call liebherr("nochmal")` </small>
 
 
 
@@ -990,7 +990,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function rekursiv(tx as string) as string
 ' wird nirgendwo aufgerufen.
 ' Anzahl weiterer internen Aufrufe : 3 (1 + rekursiv sich selbst + 1)
@@ -1021,7 +1021,7 @@ Private Function rekursiv(tx as string) as string
 
 End Function
 
-```
+`
 
 </details>
 
@@ -1075,7 +1075,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```main```](#main) : <small>  [Zeile 112] : ```        wert = subtrahieren(i, i - 1) ' Erklärung siehe @ Func!``` </small>
+- [`main`](#main) : <small>  [Zeile 112] : `        wert = subtrahieren(i, i - 1) ' Erklärung siehe @ Func!` </small>
 
 
 
@@ -1107,7 +1107,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```addieren```](#addieren) : <small>  [Zeile 77] : ```    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben``` </small>
+- [`addieren`](#addieren) : <small>  [Zeile 77] : `    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben` </small>
 
 
 
@@ -1140,7 +1140,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function subtrahieren(a as integer, b as integer) as integer
 ' Anzahl der Referenzierungen im Modul: 1
 ' Anzahl weiterer internen Aufrufe : 1
@@ -1156,7 +1156,7 @@ Private Function subtrahieren(a as integer, b as integer) as integer
 
 end Function
 
-```
+`
 
 </details>
 

--- a/output_data/beispiel_modul.bas - Dokumentation.html
+++ b/output_data/beispiel_modul.bas - Dokumentation.html
@@ -130,35 +130,35 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 97] : ```    call liebherr``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 97] : `    call liebherr` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 98] : ```    call liebherr ' Aufruf``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 98] : `    call liebherr ' Aufruf` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 100] : ```    call liebherr("ERROR") ' Aufruf waere zwar ungültig, aber Prozedur könnte ja anders aussehen!``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 100] : `    call liebherr("ERROR") ' Aufruf waere zwar ungültig, aber Prozedur könnte ja anders aussehen!` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 103] : ```    var = liebherr``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 103] : `    var = liebherr` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 104] : ```    var = liebherr("gvkil")``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 104] : `    var = liebherr("gvkil")` </small>
 
 
 
@@ -191,7 +191,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Public Sub bauer()
 ' Anzahl der Referenzierungen im Modul: 0
 ' Anzahl weiterer internen Aufrufe : 5
@@ -217,7 +217,7 @@ Public Sub bauer()
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -324,7 +324,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
    Sub casio()
     ' Anzahl der Referenzierungen im Modul: 0
     ' Anzahl weiterer internen Aufrufe : 0
@@ -336,7 +336,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -387,17 +387,17 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```main```](#main) : <small>  [Zeile 77] : ```    call liebherr``` </small>
+- [`main`](#main) : <small>  [Zeile 77] : `    call liebherr` </small>
 
-- [```bauer```](#bauer) : <small>  [Zeile 97] : ```    call liebherr``` </small>
+- [`bauer`](#bauer) : <small>  [Zeile 97] : `    call liebherr` </small>
 
-- [```bauer```](#bauer) : <small>  [Zeile 98] : ```    call liebherr ' Aufruf``` </small>
+- [`bauer`](#bauer) : <small>  [Zeile 98] : `    call liebherr ' Aufruf` </small>
 
-- [```bauer```](#bauer) : <small>  [Zeile 100] : ```    call liebherr("ERROR") ' Aufruf waere zwar ungültig, aber Prozedur könnte ja anders aussehen!``` </small>
+- [`bauer`](#bauer) : <small>  [Zeile 100] : `    call liebherr("ERROR") ' Aufruf waere zwar ungültig, aber Prozedur könnte ja anders aussehen!` </small>
 
-- [```bauer```](#bauer) : <small>  [Zeile 103] : ```    var = liebherr``` </small>
+- [`bauer`](#bauer) : <small>  [Zeile 103] : `    var = liebherr` </small>
 
-- [```bauer```](#bauer) : <small>  [Zeile 104] : ```    var = liebherr("gvkil")``` </small>
+- [`bauer`](#bauer) : <small>  [Zeile 104] : `    var = liebherr("gvkil")` </small>
 
 
 
@@ -455,7 +455,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
    Sub liebherr()
    ' Anzahl der Referenzierungen im Modul: 6
     ' Anzahl weiterer internen Aufrufe : 0
@@ -468,7 +468,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -553,17 +553,17 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```addieren```](#addieren) : <small>  [Zeile 71] : ```        wert = addieren(i, i)``` </small>
+- [`addieren`](#addieren) : <small>  [Zeile 71] : `        wert = addieren(i, i)` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```subtrahieren```](#subtrahieren) : <small>  [Zeile 72] : ```        wert = subtrahieren(i, i - 1) ' Erklärung siehe @ Func!``` </small>
+- [`subtrahieren`](#subtrahieren) : <small>  [Zeile 72] : `        wert = subtrahieren(i, i - 1) ' Erklärung siehe @ Func!` </small>
 
 
-  - [```addieren```](#addieren) : <small>  [Zeile 41] : ```    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben``` </small>
+  - [`addieren`](#addieren) : <small>  [Zeile 41] : `    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben` </small>
 
 
 
@@ -574,7 +574,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 77] : ```    call liebherr``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 77] : `    call liebherr` </small>
 
 
 
@@ -606,7 +606,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Sub main()
 ' Anzahl der Referenzierungen im Modul: 0
 ' Anzahl weiterer internen Aufrufe : 3
@@ -638,7 +638,7 @@ Private Sub main()
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -698,9 +698,9 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```subtrahieren```](#subtrahieren) : <small>  [Zeile 41] : ```    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben``` </small>
+- [`subtrahieren`](#subtrahieren) : <small>  [Zeile 41] : `    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben` </small>
 
-- [```main```](#main) : <small>  [Zeile 71] : ```        wert = addieren(i, i)``` </small>
+- [`main`](#main) : <small>  [Zeile 71] : `        wert = addieren(i, i)` </small>
 
 
 
@@ -758,7 +758,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function addieren(a as integer, b as integer) as integer
 ' Anzahl der Referenzierungen im Modul: 2
 ' Anzahl weiterer internen Aufrufe : 0
@@ -773,7 +773,7 @@ Private Function addieren(a as integer, b as integer) as integer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -827,7 +827,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```main```](#main) : <small>  [Zeile 72] : ```        wert = subtrahieren(i, i - 1) ' Erklärung siehe @ Func!``` </small>
+- [`main`](#main) : <small>  [Zeile 72] : `        wert = subtrahieren(i, i - 1) ' Erklärung siehe @ Func!` </small>
 
 
 
@@ -859,7 +859,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```addieren```](#addieren) : <small>  [Zeile 41] : ```    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben``` </small>
+- [`addieren`](#addieren) : <small>  [Zeile 41] : `    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben` </small>
 
 
 
@@ -892,7 +892,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function subtrahieren(a as integer, b as integer) as integer
 ' Anzahl der Referenzierungen im Modul: 1
 ' Anzahl weiterer internen Aufrufe : 1
@@ -908,7 +908,7 @@ Private Function subtrahieren(a as integer, b as integer) as integer
 
 end Function
 
-```
+`
 
 </details>
 

--- a/output_data/beispiel_modul1.bas - Dokumentation.html
+++ b/output_data/beispiel_modul1.bas - Dokumentation.html
@@ -177,7 +177,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 744] : ```                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 744] : `                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)` </small>
 
 
 
@@ -235,7 +235,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub InsertImageFromFileToCell(zeile As Integer, spalte As Integer, image_path As String, Optional fitTo As String = "Width")
 ' Private Sub InsertImageFromFileToCell(zeile As Integer, spalte As Integer, image_path As String)
 
@@ -265,7 +265,7 @@ Private Sub InsertImageFromFileToCell(zeile As Integer, spalte As Integer, image
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -313,7 +313,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 767] : ```    Call SeitenformatNextPosition(oSeite)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 767] : `    Call SeitenformatNextPosition(oSeite)` </small>
 
 
 
@@ -371,7 +371,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub SeitenformatNextPosition(oSeite As Seitenformat)
 ' Modifiziert die Attribute des Objektes so, dass die naechste Position in den Attributen gespeichert wird
 
@@ -391,7 +391,7 @@ Private Sub SeitenformatNextPosition(oSeite As Seitenformat)
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -495,13 +495,13 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub THIS_VERSION__1_17()
 ' Dummy-Methode, um Versionsnummer in MacroList anzeigen zu lassen...
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -549,7 +549,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```notengriffeErzeugen```](#notengriffeErzeugen) : <small>  [Zeile 1192] : ```        Call applyLayoutPrintArea(oSeite)``` </small>
+- [`notengriffeErzeugen`](#notengriffeErzeugen) : <small>  [Zeile 1192] : `        Call applyLayoutPrintArea(oSeite)` </small>
 
 
 
@@ -581,7 +581,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```getCountsOfColumnsToPrint```](#getCountsOfColumnsToPrint) : <small>  [Zeile 254] : ```    anzahlColumnsToPrint = getCountsOfColumnsToPrint(oSeite)``` </small>
+- [`getCountsOfColumnsToPrint`](#getCountsOfColumnsToPrint) : <small>  [Zeile 254] : `    anzahlColumnsToPrint = getCountsOfColumnsToPrint(oSeite)` </small>
 
 
 
@@ -614,7 +614,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Sub applyLayoutPrintArea(oSeite As Seitenformat)
     ' Legt den Druckbereich der einzelnen Seite fest, in Abhängigkeit der tatsaechlich vorhandenen Anzahl von Spalten:
 
@@ -639,7 +639,7 @@ Private Sub applyLayoutPrintArea(oSeite As Seitenformat)
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -688,7 +688,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```notengriffeErzeugen```](#notengriffeErzeugen) : <small>  [Zeile 1201] : ```    Call applyLayoutToAllPages(oSeite)``` </small>
+- [`notengriffeErzeugen`](#notengriffeErzeugen) : <small>  [Zeile 1201] : `    Call applyLayoutToAllPages(oSeite)` </small>
 
 
 
@@ -720,22 +720,22 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```applyLayoutToSinglePage```](#applyLayoutToSinglePage) : <small>  [Zeile 150] : ```        Call applyLayoutToSinglePage(ws, page, oSeite)``` </small>
+- [`applyLayoutToSinglePage`](#applyLayoutToSinglePage) : <small>  [Zeile 150] : `        Call applyLayoutToSinglePage(ws, page, oSeite)` </small>
 
 
-  - [```getCountsOfColumnsToPrint```](#getCountsOfColumnsToPrint) : <small>  [Zeile 179] : ```    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)``` </small>
-
-
-
-      - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
-
-  - [```mergeCells```](#mergeCells) : <small>  [Zeile 195] : ```    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)``` </small>
+  - [`getCountsOfColumnsToPrint`](#getCountsOfColumnsToPrint) : <small>  [Zeile 179] : `    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-  - [```mergeCells```](#mergeCells) : <small>  [Zeile 211] : ```    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)``` </small>
+  - [`mergeCells`](#mergeCells) : <small>  [Zeile 195] : `    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)` </small>
+
+
+
+      - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
+
+  - [`mergeCells`](#mergeCells) : <small>  [Zeile 211] : `    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)` </small>
 
 
 
@@ -771,7 +771,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Sub applyLayoutToAllPages(oSeite As Seitenformat)
     ' Durchlaeuft alle erstellten Tabellenblaetter und schleust durch zu einer Anwendungsfunktion, die wiederum  den Titel und andere Dinge in diese Blaetter  ein. Als oSeite wird das zuletzt-verwendete Objekt verwendet - benoetigt werden neben den ALLGEMEINEN UND KONSTANTEN Attributen nur die Angabe der pageNum als Gesamtseitenzahl.
     ' Zusaetzlich wird AUSSERHALB DES DRUCKBEREICHES auch ein Hyperlink zur Steuertabelle eingefuegt...
@@ -792,7 +792,7 @@ Private Sub applyLayoutToAllPages(oSeite As Seitenformat)
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -840,7 +840,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```applyLayoutToAllPages```](#applyLayoutToAllPages) : <small>  [Zeile 150] : ```        Call applyLayoutToSinglePage(ws, page, oSeite)``` </small>
+- [`applyLayoutToAllPages`](#applyLayoutToAllPages) : <small>  [Zeile 150] : `        Call applyLayoutToSinglePage(ws, page, oSeite)` </small>
 
 
 
@@ -872,19 +872,19 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```getCountsOfColumnsToPrint```](#getCountsOfColumnsToPrint) : <small>  [Zeile 179] : ```    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)``` </small>
+- [`getCountsOfColumnsToPrint`](#getCountsOfColumnsToPrint) : <small>  [Zeile 179] : `    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```mergeCells```](#mergeCells) : <small>  [Zeile 195] : ```    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)``` </small>
+- [`mergeCells`](#mergeCells) : <small>  [Zeile 195] : `    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```mergeCells```](#mergeCells) : <small>  [Zeile 211] : ```    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)``` </small>
+- [`mergeCells`](#mergeCells) : <small>  [Zeile 211] : `    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)` </small>
 
 
 
@@ -917,7 +917,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Sub applyLayoutToSinglePage(wsResult As Worksheet, thisPageNum As Integer, oSeite As Seitenformat)
     ' Zusaetzlich wird AUSSERHALB DES DRUCKBEREICHES auch ein Hyperlink zur Steuertabelle eingefuegt...
 
@@ -986,7 +986,7 @@ Private Sub applyLayoutToSinglePage(wsResult As Worksheet, thisPageNum As Intege
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -1034,7 +1034,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```notengriffeErzeugen```](#notengriffeErzeugen) : <small>  [Zeile 1191] : ```        Call erstelleKonvertierteSeite(startzeileSteuertabelle, oSeite)``` </small>
+- [`notengriffeErzeugen`](#notengriffeErzeugen) : <small>  [Zeile 1191] : `        Call erstelleKonvertierteSeite(startzeileSteuertabelle, oSeite)` </small>
 
 
 
@@ -1066,10 +1066,10 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```insertSheet```](#insertSheet) : <small>  [Zeile 662] : ```        Call insertSheet(oSeite.blattname & pageNum)``` </small>
+- [`insertSheet`](#insertSheet) : <small>  [Zeile 662] : `        Call insertSheet(oSeite.blattname & pageNum)` </small>
 
 
-  - [```existsSheetname```](#existsSheetname) : <small>  [Zeile 283] : ```        If existsSheetname(sheetname) = False Then``` </small>
+  - [`existsSheetname`](#existsSheetname) : <small>  [Zeile 283] : `        If existsSheetname(sheetname) = False Then` </small>
 
 
 
@@ -1079,19 +1079,19 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 677] : ```            If konvertiereZeile(zeileSteuertabelle, oSeite) = False Then``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 677] : `            If konvertiereZeile(zeileSteuertabelle, oSeite) = False Then` </small>
 
 
-  - [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 723] : ```                    oReplacer = getReplacerPre1(stichwort)``` </small>
+  - [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 723] : `                    oReplacer = getReplacerPre1(stichwort)` </small>
 
 
-      - [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+      - [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-      - [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+      - [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -1101,19 +1101,19 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```getReplacerPre2```](#getReplacerPre2) : <small>  [Zeile 725] : ```                    oReplacer = getReplacerPre2(stichwort)``` </small>
+  - [`getReplacerPre2`](#getReplacerPre2) : <small>  [Zeile 725] : `                    oReplacer = getReplacerPre2(stichwort)` </small>
 
 
-      - [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 445] : ```    getReplacerPre2 = getReplacerPre1(stichwort)``` </small>
+      - [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 445] : `    getReplacerPre2 = getReplacerPre1(stichwort)` </small>
 
 
-        - [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+        - [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
           - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-        - [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+        - [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -1127,38 +1127,38 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```getReplacerNote```](#getReplacerNote) : <small>  [Zeile 727] : ```                    oReplacer = getReplacerNote(stichwort)``` </small>
+  - [`getReplacerNote`](#getReplacerNote) : <small>  [Zeile 727] : `                    oReplacer = getReplacerNote(stichwort)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```getReplacerCount```](#getReplacerCount) : <small>  [Zeile 729] : ```                    oReplacer = getReplacerCount(stichwort)``` </small>
+  - [`getReplacerCount`](#getReplacerCount) : <small>  [Zeile 729] : `                    oReplacer = getReplacerCount(stichwort)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```getReplacerPost```](#getReplacerPost) : <small>  [Zeile 731] : ```                    oReplacer = getReplacerPost(stichwort)``` </small>
+  - [`getReplacerPost`](#getReplacerPost) : <small>  [Zeile 731] : `                    oReplacer = getReplacerPost(stichwort)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```getReplacerEmpty```](#getReplacerEmpty) : <small>  [Zeile 733] : ```                    oReplacer = getReplacerEmpty()``` </small>
+  - [`getReplacerEmpty`](#getReplacerEmpty) : <small>  [Zeile 733] : `                    oReplacer = getReplacerEmpty()` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```getFilePath```](#getFilePath) : <small>  [Zeile 742] : ```                pathImage = getFilePath(oReplacer.value)``` </small>
+  - [`getFilePath`](#getFilePath) : <small>  [Zeile 742] : `                pathImage = getFilePath(oReplacer.value)` </small>
 
 
-      - [```getFilePath```](#getFilePath) : <small>  [Zeile 366] : ```    getFilePath = getFilePath(ERROR_FILENAME)``` </small>
+      - [`getFilePath`](#getFilePath) : <small>  [Zeile 366] : `    getFilePath = getFilePath(ERROR_FILENAME)` </small>
 
 
         - <small> *... recursivly calls itself under certain conditions ...* </small> 
@@ -1168,25 +1168,25 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```InsertImageFromFileToCell```](#InsertImageFromFileToCell) : <small>  [Zeile 744] : ```                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)``` </small>
+  - [`InsertImageFromFileToCell`](#InsertImageFromFileToCell) : <small>  [Zeile 744] : `                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-  - [```getTypeOfFollowingSeperatorLine```](#getTypeOfFollowingSeperatorLine) : <small>  [Zeile 757] : ```    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)``` </small>
+  - [`getTypeOfFollowingSeperatorLine`](#getTypeOfFollowingSeperatorLine) : <small>  [Zeile 757] : `    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-  - [```insertFrameLineBelow```](#insertFrameLineBelow) : <small>  [Zeile 762] : ```        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))``` </small>
+  - [`insertFrameLineBelow`](#insertFrameLineBelow) : <small>  [Zeile 762] : `        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-  - [```SeitenformatNextPosition```](#SeitenformatNextPosition) : <small>  [Zeile 767] : ```    Call SeitenformatNextPosition(oSeite)``` </small>
+  - [`SeitenformatNextPosition`](#SeitenformatNextPosition) : <small>  [Zeile 767] : `    Call SeitenformatNextPosition(oSeite)` </small>
 
 
 
@@ -1221,7 +1221,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Sub erstelleKonvertierteSeite(startzeileSteuertabelle As Integer, oSeite As Seitenformat)
     ' Erstelle neues TBB und wende Atrriubte an
 
@@ -1259,7 +1259,7 @@ Private Sub erstelleKonvertierteSeite(startzeileSteuertabelle As Integer, oSeite
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -1307,7 +1307,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```notengriffeErzeugen```](#notengriffeErzeugen) : <small>  [Zeile 1172] : ```    Call init``` </small>
+- [`notengriffeErzeugen`](#notengriffeErzeugen) : <small>  [Zeile 1172] : `    Call init` </small>
 
 
 
@@ -1365,7 +1365,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub init()
     ' Parameter fuer modulweite Variablen laden
 
@@ -1381,7 +1381,7 @@ Private Sub init()
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -1429,7 +1429,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 762] : ```        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 762] : `        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))` </small>
 
 
 
@@ -1487,7 +1487,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub insertFrameLineBelow(rowAbove As Integer, oSeite As Seitenformat, dashed As Boolean)
     ' Fuegt die unteren Rahmenlinien aller Zellen dieser Zeile im Subspaltenbereich ein
 
@@ -1515,7 +1515,7 @@ Private Sub insertFrameLineBelow(rowAbove As Integer, oSeite As Seitenformat, da
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -1563,7 +1563,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```erstelleKonvertierteSeite```](#erstelleKonvertierteSeite) : <small>  [Zeile 662] : ```        Call insertSheet(oSeite.blattname & pageNum)``` </small>
+- [`erstelleKonvertierteSeite`](#erstelleKonvertierteSeite) : <small>  [Zeile 662] : `        Call insertSheet(oSeite.blattname & pageNum)` </small>
 
 
 
@@ -1595,7 +1595,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```existsSheetname```](#existsSheetname) : <small>  [Zeile 283] : ```        If existsSheetname(sheetname) = False Then``` </small>
+- [`existsSheetname`](#existsSheetname) : <small>  [Zeile 283] : `        If existsSheetname(sheetname) = False Then` </small>
 
 
 
@@ -1627,7 +1627,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Sub insertSheet(sheetname As String)
     ' Fuegt ein neues Tabellenblatt hinzu mit dem uebergebenen Namen und modifiziert den Tabellenblattnamen, sofern dieser bereits existiert
 
@@ -1651,7 +1651,7 @@ Private Sub insertSheet(sheetname As String)
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -1699,9 +1699,9 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```applyLayoutToSinglePage```](#applyLayoutToSinglePage) : <small>  [Zeile 195] : ```    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)``` </small>
+- [`applyLayoutToSinglePage`](#applyLayoutToSinglePage) : <small>  [Zeile 195] : `    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)` </small>
 
-- [```applyLayoutToSinglePage```](#applyLayoutToSinglePage) : <small>  [Zeile 211] : ```    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)``` </small>
+- [`applyLayoutToSinglePage`](#applyLayoutToSinglePage) : <small>  [Zeile 211] : `    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)` </small>
 
 
 
@@ -1759,7 +1759,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub mergeCells(ws As Worksheet, lineFrom As Integer, columnFrom As Integer, lineTo As Integer, columnTo As Integer)
     ' Verbindet den uebergebenen Zellbereich
 
@@ -1774,7 +1774,7 @@ Private Sub mergeCells(ws As Worksheet, lineFrom As Integer, columnFrom As Integ
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -1824,7 +1824,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+- [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
@@ -1882,7 +1882,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub modifyReplacerIfSonderzeichen(oReplacer As Replacer)
     ' Prueft, ob das Stichwort einem definierten Sonderzeichen entspricht.
     ' Jedes definierte Sonderzeichen erhaelt ein expliziten Bild-Dateiname als Verknuepfung (ohne Dateiendung hier.)
@@ -1923,7 +1923,7 @@ Private Sub modifyReplacerIfSonderzeichen(oReplacer As Replacer)
 ' End Function
 End Sub
 
-```
+`
 
 </details>
 
@@ -1973,7 +1973,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+- [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -2031,7 +2031,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub modifyReplacerIfTaktwechsel(oReplacer As Replacer)
     ' Prueft, ob das Stichwort einem Taktartwechsel entspricht.
     ' Je nach Taktart wird das uebergebene Replacer-Objekt inplace modifiziert und zurueckgegeben (mal wird ein Bild gewuenscht, mal nciht...)
@@ -2073,7 +2073,7 @@ Private Sub modifyReplacerIfTaktwechsel(oReplacer As Replacer)
     Next i
 End Sub
 
-```
+`
 
 </details>
 
@@ -2150,33 +2150,33 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```init```](#init) : <small>  [Zeile 1172] : ```    Call init``` </small>
+- [`init`](#init) : <small>  [Zeile 1172] : `    Call init` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```addSeitenformat```](#addSeitenformat) : <small>  [Zeile 1183] : ```        oSeite = addSeitenformat(startzeileSteuertabelle)``` </small>
+- [`addSeitenformat`](#addSeitenformat) : <small>  [Zeile 1183] : `        oSeite = addSeitenformat(startzeileSteuertabelle)` </small>
 
 
-  - [```newSeitenformat```](#newSeitenformat) : <small>  [Zeile 970] : ```    oFormat = newSeitenformat()``` </small>
+  - [`newSeitenformat`](#newSeitenformat) : <small>  [Zeile 970] : `    oFormat = newSeitenformat()` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```identifyLastRow```](#identifyLastRow) : <small>  [Zeile 980] : ```    letzteZeileSteuertabelle = identifyLastRow(startzeileSteuertabelle, oFormat.maxAnzahlEintraege)``` </small>
+  - [`identifyLastRow`](#identifyLastRow) : <small>  [Zeile 980] : `    letzteZeileSteuertabelle = identifyLastRow(startzeileSteuertabelle, oFormat.maxAnzahlEintraege)` </small>
 
 
-    - [```newSeitenformat```](#newSeitenformat) : <small>  [Zeile 876] : ```    tempObj = newSeitenformat(readParameters:=False)``` </small>
+    - [`newSeitenformat`](#newSeitenformat) : <small>  [Zeile 876] : `    tempObj = newSeitenformat(readParameters:=False)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-    - [```areaEmpty```](#areaEmpty) : <small>  [Zeile 882] : ```        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then``` </small>
+    - [`areaEmpty`](#areaEmpty) : <small>  [Zeile 882] : `        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then` </small>
 
 
 
@@ -2191,13 +2191,13 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```erstelleKonvertierteSeite```](#erstelleKonvertierteSeite) : <small>  [Zeile 1191] : ```        Call erstelleKonvertierteSeite(startzeileSteuertabelle, oSeite)``` </small>
+- [`erstelleKonvertierteSeite`](#erstelleKonvertierteSeite) : <small>  [Zeile 1191] : `        Call erstelleKonvertierteSeite(startzeileSteuertabelle, oSeite)` </small>
 
 
-  - [```insertSheet```](#insertSheet) : <small>  [Zeile 662] : ```        Call insertSheet(oSeite.blattname & pageNum)``` </small>
+  - [`insertSheet`](#insertSheet) : <small>  [Zeile 662] : `        Call insertSheet(oSeite.blattname & pageNum)` </small>
 
 
-    - [```existsSheetname```](#existsSheetname) : <small>  [Zeile 283] : ```        If existsSheetname(sheetname) = False Then``` </small>
+    - [`existsSheetname`](#existsSheetname) : <small>  [Zeile 283] : `        If existsSheetname(sheetname) = False Then` </small>
 
 
 
@@ -2207,19 +2207,19 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 677] : ```            If konvertiereZeile(zeileSteuertabelle, oSeite) = False Then``` </small>
+  - [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 677] : `            If konvertiereZeile(zeileSteuertabelle, oSeite) = False Then` </small>
 
 
-    - [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 723] : ```                    oReplacer = getReplacerPre1(stichwort)``` </small>
+    - [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 723] : `                    oReplacer = getReplacerPre1(stichwort)` </small>
 
 
-        - [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+        - [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
           - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-        - [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+        - [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -2229,19 +2229,19 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-    - [```getReplacerPre2```](#getReplacerPre2) : <small>  [Zeile 725] : ```                    oReplacer = getReplacerPre2(stichwort)``` </small>
+    - [`getReplacerPre2`](#getReplacerPre2) : <small>  [Zeile 725] : `                    oReplacer = getReplacerPre2(stichwort)` </small>
 
 
-        - [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 445] : ```    getReplacerPre2 = getReplacerPre1(stichwort)``` </small>
+        - [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 445] : `    getReplacerPre2 = getReplacerPre1(stichwort)` </small>
 
 
-          - [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+          - [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
             - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-          - [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+          - [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -2255,38 +2255,38 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-    - [```getReplacerNote```](#getReplacerNote) : <small>  [Zeile 727] : ```                    oReplacer = getReplacerNote(stichwort)``` </small>
+    - [`getReplacerNote`](#getReplacerNote) : <small>  [Zeile 727] : `                    oReplacer = getReplacerNote(stichwort)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-    - [```getReplacerCount```](#getReplacerCount) : <small>  [Zeile 729] : ```                    oReplacer = getReplacerCount(stichwort)``` </small>
+    - [`getReplacerCount`](#getReplacerCount) : <small>  [Zeile 729] : `                    oReplacer = getReplacerCount(stichwort)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-    - [```getReplacerPost```](#getReplacerPost) : <small>  [Zeile 731] : ```                    oReplacer = getReplacerPost(stichwort)``` </small>
+    - [`getReplacerPost`](#getReplacerPost) : <small>  [Zeile 731] : `                    oReplacer = getReplacerPost(stichwort)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-    - [```getReplacerEmpty```](#getReplacerEmpty) : <small>  [Zeile 733] : ```                    oReplacer = getReplacerEmpty()``` </small>
+    - [`getReplacerEmpty`](#getReplacerEmpty) : <small>  [Zeile 733] : `                    oReplacer = getReplacerEmpty()` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-    - [```getFilePath```](#getFilePath) : <small>  [Zeile 742] : ```                pathImage = getFilePath(oReplacer.value)``` </small>
+    - [`getFilePath`](#getFilePath) : <small>  [Zeile 742] : `                pathImage = getFilePath(oReplacer.value)` </small>
 
 
-        - [```getFilePath```](#getFilePath) : <small>  [Zeile 366] : ```    getFilePath = getFilePath(ERROR_FILENAME)``` </small>
+        - [`getFilePath`](#getFilePath) : <small>  [Zeile 366] : `    getFilePath = getFilePath(ERROR_FILENAME)` </small>
 
 
           - <small> *... recursivly calls itself under certain conditions ...* </small> 
@@ -2296,25 +2296,25 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-    - [```InsertImageFromFileToCell```](#InsertImageFromFileToCell) : <small>  [Zeile 744] : ```                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)``` </small>
+    - [`InsertImageFromFileToCell`](#InsertImageFromFileToCell) : <small>  [Zeile 744] : `                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-    - [```getTypeOfFollowingSeperatorLine```](#getTypeOfFollowingSeperatorLine) : <small>  [Zeile 757] : ```    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)``` </small>
+    - [`getTypeOfFollowingSeperatorLine`](#getTypeOfFollowingSeperatorLine) : <small>  [Zeile 757] : `    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-    - [```insertFrameLineBelow```](#insertFrameLineBelow) : <small>  [Zeile 762] : ```        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))``` </small>
+    - [`insertFrameLineBelow`](#insertFrameLineBelow) : <small>  [Zeile 762] : `        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-    - [```SeitenformatNextPosition```](#SeitenformatNextPosition) : <small>  [Zeile 767] : ```    Call SeitenformatNextPosition(oSeite)``` </small>
+    - [`SeitenformatNextPosition`](#SeitenformatNextPosition) : <small>  [Zeile 767] : `    Call SeitenformatNextPosition(oSeite)` </small>
 
 
 
@@ -2327,10 +2327,10 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```applyLayoutPrintArea```](#applyLayoutPrintArea) : <small>  [Zeile 1192] : ```        Call applyLayoutPrintArea(oSeite)``` </small>
+- [`applyLayoutPrintArea`](#applyLayoutPrintArea) : <small>  [Zeile 1192] : `        Call applyLayoutPrintArea(oSeite)` </small>
 
 
-  - [```getCountsOfColumnsToPrint```](#getCountsOfColumnsToPrint) : <small>  [Zeile 254] : ```    anzahlColumnsToPrint = getCountsOfColumnsToPrint(oSeite)``` </small>
+  - [`getCountsOfColumnsToPrint`](#getCountsOfColumnsToPrint) : <small>  [Zeile 254] : `    anzahlColumnsToPrint = getCountsOfColumnsToPrint(oSeite)` </small>
 
 
 
@@ -2341,25 +2341,25 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```applyLayoutToAllPages```](#applyLayoutToAllPages) : <small>  [Zeile 1201] : ```    Call applyLayoutToAllPages(oSeite)``` </small>
+- [`applyLayoutToAllPages`](#applyLayoutToAllPages) : <small>  [Zeile 1201] : `    Call applyLayoutToAllPages(oSeite)` </small>
 
 
-  - [```applyLayoutToSinglePage```](#applyLayoutToSinglePage) : <small>  [Zeile 150] : ```        Call applyLayoutToSinglePage(ws, page, oSeite)``` </small>
+  - [`applyLayoutToSinglePage`](#applyLayoutToSinglePage) : <small>  [Zeile 150] : `        Call applyLayoutToSinglePage(ws, page, oSeite)` </small>
 
 
-    - [```getCountsOfColumnsToPrint```](#getCountsOfColumnsToPrint) : <small>  [Zeile 179] : ```    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)``` </small>
-
-
-
-        - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
-
-    - [```mergeCells```](#mergeCells) : <small>  [Zeile 195] : ```    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)``` </small>
+    - [`getCountsOfColumnsToPrint`](#getCountsOfColumnsToPrint) : <small>  [Zeile 179] : `    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-    - [```mergeCells```](#mergeCells) : <small>  [Zeile 211] : ```    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)``` </small>
+    - [`mergeCells`](#mergeCells) : <small>  [Zeile 195] : `    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)` </small>
+
+
+
+        - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
+
+    - [`mergeCells`](#mergeCells) : <small>  [Zeile 211] : `    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)` </small>
 
 
 
@@ -2373,7 +2373,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```printLastSheetsAsPdf```](#printLastSheetsAsPdf) : <small>  [Zeile 1210] : ```        Call printLastSheetsAsPdf(pageNum)``` </small>
+- [`printLastSheetsAsPdf`](#printLastSheetsAsPdf) : <small>  [Zeile 1210] : `        Call printLastSheetsAsPdf(pageNum)` </small>
 
 
 
@@ -2406,7 +2406,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Public Sub notengriffeErzeugen()
 
     ' Initialisieren der modulweiten Variablen (Worksheets usw...)
@@ -2457,7 +2457,7 @@ Public Sub notengriffeErzeugen()
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -2505,7 +2505,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```notengriffeErzeugen```](#notengriffeErzeugen) : <small>  [Zeile 1210] : ```        Call printLastSheetsAsPdf(pageNum)``` </small>
+- [`notengriffeErzeugen`](#notengriffeErzeugen) : <small>  [Zeile 1210] : `        Call printLastSheetsAsPdf(pageNum)` </small>
 
 
 
@@ -2563,7 +2563,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Sub printLastSheetsAsPdf(anzahlSheets As Integer)
 ' Speichert die hintersten (ERgebnis-Tabellenblaetter) als PDF ab, inkl. Skalierung auf eine Seite der Spalten.
 
@@ -2641,7 +2641,7 @@ Sub printLastSheetsAsPdf(anzahlSheets As Integer)
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -2718,7 +2718,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```getProjectTitle```](#getProjectTitle) : <small>  [Zeile 111] : ```    MsgBox "Alle generierten Tabellenblaetter wurden geloescht. Dieser Vorgang kann nicht rueckgaengig gemacht werden! (--> falls Falsch ginge ggf. schliessen ohne speichern, sofern alle relevanten Modifikationen vorab gespeichert wurden...)", vbOK, getProjectTitle()``` </small>
+- [`getProjectTitle`](#getProjectTitle) : <small>  [Zeile 111] : `    MsgBox "Alle generierten Tabellenblaetter wurden geloescht. Dieser Vorgang kann nicht rueckgaengig gemacht werden! (--> falls Falsch ginge ggf. schliessen ohne speichern, sofern alle relevanten Modifikationen vorab gespeichert wurden...)", vbOK, getProjectTitle()` </small>
 
 
 
@@ -2751,7 +2751,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Sub resetWorkbook()
 
     If InputBox("Sollen alle generierten Tabellenblaetter UNWIDERUFLICH ENTFERNT werden? (dann eingabe von: 'y', sonst was beliebiges anderes)", getProjectTitle()) <> "y" Then
@@ -2780,7 +2780,7 @@ Sub resetWorkbook()
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -2836,7 +2836,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```notengriffeErzeugen```](#notengriffeErzeugen) : <small>  [Zeile 1183] : ```        oSeite = addSeitenformat(startzeileSteuertabelle)``` </small>
+- [`notengriffeErzeugen`](#notengriffeErzeugen) : <small>  [Zeile 1183] : `        oSeite = addSeitenformat(startzeileSteuertabelle)` </small>
 
 
 
@@ -2868,23 +2868,23 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```newSeitenformat```](#newSeitenformat) : <small>  [Zeile 970] : ```    oFormat = newSeitenformat()``` </small>
+- [`newSeitenformat`](#newSeitenformat) : <small>  [Zeile 970] : `    oFormat = newSeitenformat()` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```identifyLastRow```](#identifyLastRow) : <small>  [Zeile 980] : ```    letzteZeileSteuertabelle = identifyLastRow(startzeileSteuertabelle, oFormat.maxAnzahlEintraege)``` </small>
+- [`identifyLastRow`](#identifyLastRow) : <small>  [Zeile 980] : `    letzteZeileSteuertabelle = identifyLastRow(startzeileSteuertabelle, oFormat.maxAnzahlEintraege)` </small>
 
 
-  - [```newSeitenformat```](#newSeitenformat) : <small>  [Zeile 876] : ```    tempObj = newSeitenformat(readParameters:=False)``` </small>
+  - [`newSeitenformat`](#newSeitenformat) : <small>  [Zeile 876] : `    tempObj = newSeitenformat(readParameters:=False)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-  - [```areaEmpty```](#areaEmpty) : <small>  [Zeile 882] : ```        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then``` </small>
+  - [`areaEmpty`](#areaEmpty) : <small>  [Zeile 882] : `        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then` </small>
 
 
 
@@ -2921,7 +2921,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function addSeitenformat(startzeileSteuertabelle As Integer) As Seitenformat
 ' Erstellt ein Objekt des Typs Seitenformat und initialisiert die Konstanten Werte sowie zusaetzlich berechnete.
 ' Berechnet alle Attribute, das Obj wird zurück gegeben, auf Grundlage von diesem kann ein neues Blatt genereiert werden.
@@ -2964,7 +2964,7 @@ Private Function addSeitenformat(startzeileSteuertabelle As Integer) As Seitenfo
 
 End Function
 
-```
+`
 
 </details>
 
@@ -3015,7 +3015,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```identifyLastRow```](#identifyLastRow) : <small>  [Zeile 882] : ```        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then``` </small>
+- [`identifyLastRow`](#identifyLastRow) : <small>  [Zeile 882] : `        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then` </small>
 
 
 
@@ -3073,7 +3073,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function areaEmpty(ws As Worksheet, lineFrom As Integer, columnFrom As Integer, lineTo As Integer, columnTo As Integer)
     ' Prueft einen Bereich auf leere Zellen.
     ' Rueckgabewerte:
@@ -3103,7 +3103,7 @@ Private Function areaEmpty(ws As Worksheet, lineFrom As Integer, columnFrom As I
 
     End Function
 
-```
+`
 
 </details>
 
@@ -3150,7 +3150,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```insertSheet```](#insertSheet) : <small>  [Zeile 283] : ```        If existsSheetname(sheetname) = False Then``` </small>
+- [`insertSheet`](#insertSheet) : <small>  [Zeile 283] : `        If existsSheetname(sheetname) = False Then` </small>
 
 
 
@@ -3208,7 +3208,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function existsSheetname(name As String) As Boolean
 
     Dim ws As Worksheet
@@ -3226,7 +3226,7 @@ Private Function existsSheetname(name As String) As Boolean
 
 End Function
 
-```
+`
 
 </details>
 
@@ -3275,9 +3275,9 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```applyLayoutToSinglePage```](#applyLayoutToSinglePage) : <small>  [Zeile 179] : ```    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)``` </small>
+- [`applyLayoutToSinglePage`](#applyLayoutToSinglePage) : <small>  [Zeile 179] : `    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)` </small>
 
-- [```applyLayoutPrintArea```](#applyLayoutPrintArea) : <small>  [Zeile 254] : ```    anzahlColumnsToPrint = getCountsOfColumnsToPrint(oSeite)``` </small>
+- [`applyLayoutPrintArea`](#applyLayoutPrintArea) : <small>  [Zeile 254] : `    anzahlColumnsToPrint = getCountsOfColumnsToPrint(oSeite)` </small>
 
 
 
@@ -3335,7 +3335,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Function getCountsOfColumnsToPrint(oSeite As Seitenformat) As Integer
     ' Berechnet die tatsaechliche Anzahl der zu druckenden Spalten
     ' Dafuer wird die letzte Spalte abgezogen, weil wg. Blattrand keine zusaetzliche Luft erforderlich ist:
@@ -3344,7 +3344,7 @@ Function getCountsOfColumnsToPrint(oSeite As Seitenformat) As Integer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -3393,9 +3393,9 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```getFilePath```](#getFilePath) : <small>  [Zeile 366] : ```    getFilePath = getFilePath(ERROR_FILENAME)``` </small>
+- [`getFilePath`](#getFilePath) : <small>  [Zeile 366] : `    getFilePath = getFilePath(ERROR_FILENAME)` </small>
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 742] : ```                pathImage = getFilePath(oReplacer.value)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 742] : `                pathImage = getFilePath(oReplacer.value)` </small>
 
 
 
@@ -3427,7 +3427,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```getFilePath```](#getFilePath) : <small>  [Zeile 366] : ```    getFilePath = getFilePath(ERROR_FILENAME)``` </small>
+- [`getFilePath`](#getFilePath) : <small>  [Zeile 366] : `    getFilePath = getFilePath(ERROR_FILENAME)` </small>
 
 
   - <small> *... recursivly calls itself under certain conditions ...* </small> 
@@ -3459,7 +3459,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function getFilePath(stichwort As String)
     ' Generiert einen Path zur Bilddatei basierend auf einem Stichwort.
     ' Sofern es keine passende Datei gibt, wird ein Platzhalter-Bild referenziert, durch das ein FEHLER verdeutlcihet wird.
@@ -3492,7 +3492,7 @@ Private Function getFilePath(stichwort As String)
 
 End Function
 
-```
+`
 
 </details>
 
@@ -3597,7 +3597,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function getModifiedKeyIfTaktwechsel(stichwort As String) As String
     ' Prueft, ob das Stichwort einem Taktartwechsel entspricht.
     ' Dazu werden konkrete Stichworte geprueftund durch ein alternativ-stichwort fuer einen Dateinamen ersetzt zurueckgegeben.
@@ -3626,7 +3626,7 @@ Private Function getModifiedKeyIfTaktwechsel(stichwort As String) As String
 
 End Function
 
-```
+`
 
 </details>
 
@@ -3673,7 +3673,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```resetWorkbook```](#resetWorkbook) : <small>  [Zeile 111] : ```    MsgBox "Alle generierten Tabellenblaetter wurden geloescht. Dieser Vorgang kann nicht rueckgaengig gemacht werden! (--> falls Falsch ginge ggf. schliessen ohne speichern, sofern alle relevanten Modifikationen vorab gespeichert wurden...)", vbOK, getProjectTitle()``` </small>
+- [`resetWorkbook`](#resetWorkbook) : <small>  [Zeile 111] : `    MsgBox "Alle generierten Tabellenblaetter wurden geloescht. Dieser Vorgang kann nicht rueckgaengig gemacht werden! (--> falls Falsch ginge ggf. schliessen ohne speichern, sofern alle relevanten Modifikationen vorab gespeichert wurden...)", vbOK, getProjectTitle()` </small>
 
 
 
@@ -3731,14 +3731,14 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Function getProjectTitle() As String
 
     getProjectTitle = "Notengriff-Converter"
 
 End Function
 
-```
+`
 
 </details>
 
@@ -3786,7 +3786,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 729] : ```                    oReplacer = getReplacerCount(stichwort)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 729] : `                    oReplacer = getReplacerCount(stichwort)` </small>
 
 
 
@@ -3844,7 +3844,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function getReplacerCount(stichwort As String) As Replacer
     ' Prueft das Stichwort fuer diese spezielle Spalte/ das Attribut und gibt darauf basierend eine ZEichenkette als Replacer zurueck. Diese Zeichenkette entspricht entweder dem Stichwort (Text uebernehmen) oder dem Dateipfad zu einem Bilddatei.
 
@@ -3861,7 +3861,7 @@ Private Function getReplacerCount(stichwort As String) As Replacer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -3909,7 +3909,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 733] : ```                    oReplacer = getReplacerEmpty()``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 733] : `                    oReplacer = getReplacerEmpty()` </small>
 
 
 
@@ -3967,7 +3967,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function getReplacerEmpty() As Replacer
     ' Gibt leeren Replacer zurueck
 
@@ -3981,7 +3981,7 @@ Private Function getReplacerEmpty() As Replacer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -4029,7 +4029,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 727] : ```                    oReplacer = getReplacerNote(stichwort)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 727] : `                    oReplacer = getReplacerNote(stichwort)` </small>
 
 
 
@@ -4087,7 +4087,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function getReplacerNote(stichwort As String) As Replacer
     ' Prueft das Stichwort fuer diese spezielle Spalte/ das Attribut und gibt darauf basierend eine ZEichenkette als Replacer zurueck. Diese Zeichenkette entspricht entweder dem Stichwort (Text uebernehmen) oder dem Dateipfad zu einem Bilddatei.
 
@@ -4117,7 +4117,7 @@ Private Function getReplacerNote(stichwort As String) As Replacer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -4165,7 +4165,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 731] : ```                    oReplacer = getReplacerPost(stichwort)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 731] : `                    oReplacer = getReplacerPost(stichwort)` </small>
 
 
 
@@ -4223,7 +4223,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function getReplacerPost(stichwort As String) As Replacer
     ' Prueft das Stichwort fuer diese spezielle Spalte/ das Attribut und gibt darauf basierend eine ZEichenkette als Replacer zurueck. Diese Zeichenkette entspricht entweder dem Stichwort (Text uebernehmen) oder dem Dateipfad zu einem Bilddatei.
 
@@ -4238,7 +4238,7 @@ Private Function getReplacerPost(stichwort As String) As Replacer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -4286,9 +4286,9 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```getReplacerPre2```](#getReplacerPre2) : <small>  [Zeile 445] : ```    getReplacerPre2 = getReplacerPre1(stichwort)``` </small>
+- [`getReplacerPre2`](#getReplacerPre2) : <small>  [Zeile 445] : `    getReplacerPre2 = getReplacerPre1(stichwort)` </small>
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 723] : ```                    oReplacer = getReplacerPre1(stichwort)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 723] : `                    oReplacer = getReplacerPre1(stichwort)` </small>
 
 
 
@@ -4320,13 +4320,13 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+- [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+- [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -4358,7 +4358,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function getReplacerPre1(stichwort As String) As Replacer
     ' Prueft das Stichwort fuer diese spezielle Spalte/ das Attribut und gibt darauf basierend eine ZEichenkette als Replacer zurueck. Diese Zeichenkette entspricht entweder dem Stichwort (Text uebernehmen) oder dem Dateipfad zu einem Bilddatei.
 
@@ -4420,7 +4420,7 @@ Private Function getReplacerPre1(stichwort As String) As Replacer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -4468,7 +4468,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 725] : ```                    oReplacer = getReplacerPre2(stichwort)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 725] : `                    oReplacer = getReplacerPre2(stichwort)` </small>
 
 
 
@@ -4500,16 +4500,16 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 445] : ```    getReplacerPre2 = getReplacerPre1(stichwort)``` </small>
+- [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 445] : `    getReplacerPre2 = getReplacerPre1(stichwort)` </small>
 
 
-  - [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+  - [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-  - [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+  - [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -4545,7 +4545,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function getReplacerPre2(stichwort As String) As Replacer
     ' Prueft das Stichwort fuer diese spezielle Spalte/ das Attribut und gibt darauf basierend eine ZEichenkette als Replacer zurueck. Diese Zeichenkette entspricht entweder dem Stichwort (Text uebernehmen) oder dem Dateipfad zu einem Bilddatei.
 
@@ -4554,7 +4554,7 @@ Private Function getReplacerPre2(stichwort As String) As Replacer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -4604,7 +4604,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 757] : ```    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 757] : `    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)` </small>
 
 
 
@@ -4662,7 +4662,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function getTypeOfFollowingSeperatorLine(lastRowNumber As Integer, oSeite As Seitenformat) As Integer
 ' returns 0 falls kein eLinie folgt
 ' returns 1 falls durchgezogene Linie folgt
@@ -4693,7 +4693,7 @@ Private Function getTypeOfFollowingSeperatorLine(lastRowNumber As Integer, oSeit
 
 End Function
 
-```
+`
 
 </details>
 
@@ -4742,7 +4742,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```addSeitenformat```](#addSeitenformat) : <small>  [Zeile 980] : ```    letzteZeileSteuertabelle = identifyLastRow(startzeileSteuertabelle, oFormat.maxAnzahlEintraege)``` </small>
+- [`addSeitenformat`](#addSeitenformat) : <small>  [Zeile 980] : `    letzteZeileSteuertabelle = identifyLastRow(startzeileSteuertabelle, oFormat.maxAnzahlEintraege)` </small>
 
 
 
@@ -4774,13 +4774,13 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```newSeitenformat```](#newSeitenformat) : <small>  [Zeile 876] : ```    tempObj = newSeitenformat(readParameters:=False)``` </small>
+- [`newSeitenformat`](#newSeitenformat) : <small>  [Zeile 876] : `    tempObj = newSeitenformat(readParameters:=False)` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```areaEmpty```](#areaEmpty) : <small>  [Zeile 882] : ```        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then``` </small>
+- [`areaEmpty`](#areaEmpty) : <small>  [Zeile 882] : `        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then` </small>
 
 
 
@@ -4813,7 +4813,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function identifyLastRow(startzeile As Integer, maxZeilen As Integer) As Integer
     ' Liesst die STB ausgehend ab startzeile aus bis dass die Anzahl maxZeilen abgearbeitet wurde. Pro Zeile wird sich die Zeilennummer gemerkt, sofern Inhalt vorhanden ist.
     ' Ziel davon ist, dass man so erkennt, wenn die letzten n zeilen nur freizeilen sind (um manuell einen seitenumbruch zu generieren), oder ob nur etwas abstand dadurch generiert werden sollte...
@@ -4839,7 +4839,7 @@ Private Function identifyLastRow(startzeile As Integer, maxZeilen As Integer) As
 
 End Function
 
-```
+`
 
 </details>
 
@@ -4892,7 +4892,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```erstelleKonvertierteSeite```](#erstelleKonvertierteSeite) : <small>  [Zeile 677] : ```            If konvertiereZeile(zeileSteuertabelle, oSeite) = False Then``` </small>
+- [`erstelleKonvertierteSeite`](#erstelleKonvertierteSeite) : <small>  [Zeile 677] : `            If konvertiereZeile(zeileSteuertabelle, oSeite) = False Then` </small>
 
 
 
@@ -4924,16 +4924,16 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 723] : ```                    oReplacer = getReplacerPre1(stichwort)``` </small>
+- [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 723] : `                    oReplacer = getReplacerPre1(stichwort)` </small>
 
 
-    - [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+    - [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-    - [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+    - [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -4943,19 +4943,19 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```getReplacerPre2```](#getReplacerPre2) : <small>  [Zeile 725] : ```                    oReplacer = getReplacerPre2(stichwort)``` </small>
+- [`getReplacerPre2`](#getReplacerPre2) : <small>  [Zeile 725] : `                    oReplacer = getReplacerPre2(stichwort)` </small>
 
 
-    - [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 445] : ```    getReplacerPre2 = getReplacerPre1(stichwort)``` </small>
+    - [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 445] : `    getReplacerPre2 = getReplacerPre1(stichwort)` </small>
 
 
-      - [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+      - [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-      - [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+      - [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -4969,38 +4969,38 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```getReplacerNote```](#getReplacerNote) : <small>  [Zeile 727] : ```                    oReplacer = getReplacerNote(stichwort)``` </small>
+- [`getReplacerNote`](#getReplacerNote) : <small>  [Zeile 727] : `                    oReplacer = getReplacerNote(stichwort)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```getReplacerCount```](#getReplacerCount) : <small>  [Zeile 729] : ```                    oReplacer = getReplacerCount(stichwort)``` </small>
+- [`getReplacerCount`](#getReplacerCount) : <small>  [Zeile 729] : `                    oReplacer = getReplacerCount(stichwort)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```getReplacerPost```](#getReplacerPost) : <small>  [Zeile 731] : ```                    oReplacer = getReplacerPost(stichwort)``` </small>
+- [`getReplacerPost`](#getReplacerPost) : <small>  [Zeile 731] : `                    oReplacer = getReplacerPost(stichwort)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```getReplacerEmpty```](#getReplacerEmpty) : <small>  [Zeile 733] : ```                    oReplacer = getReplacerEmpty()``` </small>
+- [`getReplacerEmpty`](#getReplacerEmpty) : <small>  [Zeile 733] : `                    oReplacer = getReplacerEmpty()` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```getFilePath```](#getFilePath) : <small>  [Zeile 742] : ```                pathImage = getFilePath(oReplacer.value)``` </small>
+- [`getFilePath`](#getFilePath) : <small>  [Zeile 742] : `                pathImage = getFilePath(oReplacer.value)` </small>
 
 
-    - [```getFilePath```](#getFilePath) : <small>  [Zeile 366] : ```    getFilePath = getFilePath(ERROR_FILENAME)``` </small>
+    - [`getFilePath`](#getFilePath) : <small>  [Zeile 366] : `    getFilePath = getFilePath(ERROR_FILENAME)` </small>
 
 
       - <small> *... recursivly calls itself under certain conditions ...* </small> 
@@ -5010,25 +5010,25 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```InsertImageFromFileToCell```](#InsertImageFromFileToCell) : <small>  [Zeile 744] : ```                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)``` </small>
+- [`InsertImageFromFileToCell`](#InsertImageFromFileToCell) : <small>  [Zeile 744] : `                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```getTypeOfFollowingSeperatorLine```](#getTypeOfFollowingSeperatorLine) : <small>  [Zeile 757] : ```    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)``` </small>
+- [`getTypeOfFollowingSeperatorLine`](#getTypeOfFollowingSeperatorLine) : <small>  [Zeile 757] : `    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```insertFrameLineBelow```](#insertFrameLineBelow) : <small>  [Zeile 762] : ```        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))``` </small>
+- [`insertFrameLineBelow`](#insertFrameLineBelow) : <small>  [Zeile 762] : `        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```SeitenformatNextPosition```](#SeitenformatNextPosition) : <small>  [Zeile 767] : ```    Call SeitenformatNextPosition(oSeite)``` </small>
+- [`SeitenformatNextPosition`](#SeitenformatNextPosition) : <small>  [Zeile 767] : `    Call SeitenformatNextPosition(oSeite)` </small>
 
 
 
@@ -5060,7 +5060,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function konvertiereZeile(zeileSteuertabelle As Integer, oSeite As Seitenformat) As Boolean
     ' # TODOC: ALT:
     ' Konvertiert eine Zeile des Todo-Tabellenblattes in eine Zeile des Ergebnis-Tabellenblattes.
@@ -5138,7 +5138,7 @@ Private Function konvertiereZeile(zeileSteuertabelle As Integer, oSeite As Seite
 
 End Function
 
-```
+`
 
 </details>
 
@@ -5189,9 +5189,9 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```identifyLastRow```](#identifyLastRow) : <small>  [Zeile 876] : ```    tempObj = newSeitenformat(readParameters:=False)``` </small>
+- [`identifyLastRow`](#identifyLastRow) : <small>  [Zeile 876] : `    tempObj = newSeitenformat(readParameters:=False)` </small>
 
-- [```addSeitenformat```](#addSeitenformat) : <small>  [Zeile 970] : ```    oFormat = newSeitenformat()``` </small>
+- [`addSeitenformat`](#addSeitenformat) : <small>  [Zeile 970] : `    oFormat = newSeitenformat()` </small>
 
 
 
@@ -5249,7 +5249,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function newSeitenformat(Optional readParameters As Boolean = True) As Seitenformat
     '''''''''''''''''''''''''''''''''''''''''''''''''''''''
     ' Standard-Parameter aus TODO-Steuertabelle auslesen und Standardwerte parametrisieren.
@@ -5313,7 +5313,7 @@ Private Function newSeitenformat(Optional readParameters As Boolean = True) As S
 
 End Function
 
-```
+`
 
 </details>
 

--- a/output_data/beispiel_modul_rekursiv.bas - Dokumentation.html
+++ b/output_data/beispiel_modul_rekursiv.bas - Dokumentation.html
@@ -154,25 +154,25 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 141] : ```    call liebherr``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 141] : `    call liebherr` </small>
 
 
 
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 142] : ```    call liebherr ' Aufruf``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 142] : `    call liebherr ' Aufruf` </small>
 
 
 
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 144] : ```    call liebherr("ERROR") ' Aufruf waere zwar ungültig, aber Prozedur könnte ja anders aussehen!``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 144] : `    call liebherr("ERROR") ' Aufruf waere zwar ungültig, aber Prozedur könnte ja anders aussehen!` </small>
 
 
 
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 148] : ```    var = liebherr("gvkil")``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 148] : `    var = liebherr("gvkil")` </small>
 
 
 
@@ -203,7 +203,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Public Sub bauer()
 ' Anzahl der Referenzierungen im Modul: 0
 ' Anzahl weiterer internen Aufrufe : 5
@@ -229,7 +229,7 @@ Public Sub bauer()
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -335,7 +335,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
    Sub casio()
     ' Anzahl der Referenzierungen im Modul: 0
     ' Anzahl weiterer internen Aufrufe : 0
@@ -347,7 +347,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -398,21 +398,21 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```rekursiv```](#rekursiv) : <small>  [Zeile 55] : ```    call liebherr``` </small>
+- [`rekursiv`](#rekursiv) : <small>  [Zeile 55] : `    call liebherr` </small>
 
-- [```rekursiv```](#rekursiv) : <small>  [Zeile 57] : ```    call liebherr("nochmal")``` </small>
+- [`rekursiv`](#rekursiv) : <small>  [Zeile 57] : `    call liebherr("nochmal")` </small>
 
-- [```main```](#main) : <small>  [Zeile 117] : ```    call liebherr("vor rekursivem Aufruf")``` </small>
+- [`main`](#main) : <small>  [Zeile 117] : `    call liebherr("vor rekursivem Aufruf")` </small>
 
-- [```main```](#main) : <small>  [Zeile 121] : ```    call liebherr("NACH rekursivem Aufruf")``` </small>
+- [`main`](#main) : <small>  [Zeile 121] : `    call liebherr("NACH rekursivem Aufruf")` </small>
 
-- [```bauer```](#bauer) : <small>  [Zeile 141] : ```    call liebherr``` </small>
+- [`bauer`](#bauer) : <small>  [Zeile 141] : `    call liebherr` </small>
 
-- [```bauer```](#bauer) : <small>  [Zeile 142] : ```    call liebherr ' Aufruf``` </small>
+- [`bauer`](#bauer) : <small>  [Zeile 142] : `    call liebherr ' Aufruf` </small>
 
-- [```bauer```](#bauer) : <small>  [Zeile 144] : ```    call liebherr("ERROR") ' Aufruf waere zwar ungültig, aber Prozedur könnte ja anders aussehen!``` </small>
+- [`bauer`](#bauer) : <small>  [Zeile 144] : `    call liebherr("ERROR") ' Aufruf waere zwar ungültig, aber Prozedur könnte ja anders aussehen!` </small>
 
-- [```bauer```](#bauer) : <small>  [Zeile 148] : ```    var = liebherr("gvkil")``` </small>
+- [`bauer`](#bauer) : <small>  [Zeile 148] : `    var = liebherr("gvkil")` </small>
 
 
 
@@ -469,7 +469,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
    Sub liebherr()
    ' Anzahl der Referenzierungen im Modul: 6
     ' Anzahl weiterer internen Aufrufe : 0
@@ -482,7 +482,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -571,51 +571,51 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```addieren```](#addieren) : <small>  [Zeile 111] : ```        wert = addieren(i, i)``` </small>
+- [`addieren`](#addieren) : <small>  [Zeile 111] : `        wert = addieren(i, i)` </small>
 
 
 
 
 
-- [```subtrahieren```](#subtrahieren) : <small>  [Zeile 112] : ```        wert = subtrahieren(i, i - 1) ' Erklärung siehe @ Func!``` </small>
+- [`subtrahieren`](#subtrahieren) : <small>  [Zeile 112] : `        wert = subtrahieren(i, i - 1) ' Erklärung siehe @ Func!` </small>
 
 
-  - [```addieren```](#addieren) : <small>  [Zeile 77] : ```    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben``` </small>
-
-
-
+  - [`addieren`](#addieren) : <small>  [Zeile 77] : `    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben` </small>
 
 
 
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 117] : ```    call liebherr("vor rekursivem Aufruf")``` </small>
+
+
+
+- [`liebherr`](#liebherr) : <small>  [Zeile 117] : `    call liebherr("vor rekursivem Aufruf")` </small>
 
 
 
 
 
-- [```rekursiv```](#rekursiv) : <small>  [Zeile 119] : ```    call rekursiv``` </small>
+- [`rekursiv`](#rekursiv) : <small>  [Zeile 119] : `    call rekursiv` </small>
 
 
-  - [```addieren```](#addieren) : <small>  [Zeile 46] : ```    tx = tx + string(addieren(1,2))``` </small>
+  - [`addieren`](#addieren) : <small>  [Zeile 46] : `    tx = tx + string(addieren(1,2))` </small>
 
 
 
 
 
-  - [```rekursiv```](#rekursiv) : <small>  [Zeile 50] : ```        rekursiv(tx)``` </small>
+  - [`rekursiv`](#rekursiv) : <small>  [Zeile 50] : `        rekursiv(tx)` </small>
 
 
     - <small> *... recursivly calls itself under certain conditions ...* </small> 
 
 
-  - [```liebherr```](#liebherr) : <small>  [Zeile 55] : ```    call liebherr``` </small>
+  - [`liebherr`](#liebherr) : <small>  [Zeile 55] : `    call liebherr` </small>
 
 
 
 
-  - [```liebherr```](#liebherr) : <small>  [Zeile 57] : ```    call liebherr("nochmal")``` </small>
+  - [`liebherr`](#liebherr) : <small>  [Zeile 57] : `    call liebherr("nochmal")` </small>
 
 
 
@@ -624,7 +624,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 121] : ```    call liebherr("NACH rekursivem Aufruf")``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 121] : `    call liebherr("NACH rekursivem Aufruf")` </small>
 
 
 
@@ -655,7 +655,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Sub main()
 ' Anzahl der Referenzierungen im Modul: 0
 ' Anzahl weiterer internen Aufrufe : 5
@@ -695,7 +695,7 @@ Private Sub main()
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -755,11 +755,11 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```rekursiv```](#rekursiv) : <small>  [Zeile 46] : ```    tx = tx + string(addieren(1,2))``` </small>
+- [`rekursiv`](#rekursiv) : <small>  [Zeile 46] : `    tx = tx + string(addieren(1,2))` </small>
 
-- [```subtrahieren```](#subtrahieren) : <small>  [Zeile 77] : ```    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben``` </small>
+- [`subtrahieren`](#subtrahieren) : <small>  [Zeile 77] : `    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben` </small>
 
-- [```main```](#main) : <small>  [Zeile 111] : ```        wert = addieren(i, i)``` </small>
+- [`main`](#main) : <small>  [Zeile 111] : `        wert = addieren(i, i)` </small>
 
 
 
@@ -816,7 +816,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function addieren(a as integer, b as integer) as integer
 ' Anzahl der Referenzierungen im Modul: 2
 ' Anzahl weiterer internen Aufrufe : 0
@@ -831,7 +831,7 @@ Private Function addieren(a as integer, b as integer) as integer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -886,9 +886,9 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```rekursiv```](#rekursiv) : <small>  [Zeile 50] : ```        rekursiv(tx)``` </small>
+- [`rekursiv`](#rekursiv) : <small>  [Zeile 50] : `        rekursiv(tx)` </small>
 
-- [```main```](#main) : <small>  [Zeile 119] : ```    call rekursiv``` </small>
+- [`main`](#main) : <small>  [Zeile 119] : `    call rekursiv` </small>
 
 
 
@@ -920,24 +920,24 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```addieren```](#addieren) : <small>  [Zeile 46] : ```    tx = tx + string(addieren(1,2))``` </small>
+- [`addieren`](#addieren) : <small>  [Zeile 46] : `    tx = tx + string(addieren(1,2))` </small>
 
 
 
 
 
-- [```rekursiv```](#rekursiv) : <small>  [Zeile 50] : ```        rekursiv(tx)``` </small>
+- [`rekursiv`](#rekursiv) : <small>  [Zeile 50] : `        rekursiv(tx)` </small>
 
 
   - <small> *... recursivly calls itself under certain conditions ...* </small> 
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 55] : ```    call liebherr``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 55] : `    call liebherr` </small>
 
 
 
 
-- [```liebherr```](#liebherr) : <small>  [Zeile 57] : ```    call liebherr("nochmal")``` </small>
+- [`liebherr`](#liebherr) : <small>  [Zeile 57] : `    call liebherr("nochmal")` </small>
 
 
 
@@ -968,7 +968,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function rekursiv(tx as string) as string
 ' wird nirgendwo aufgerufen.
 ' Anzahl weiterer internen Aufrufe : 3 (1 + rekursiv sich selbst + 1)
@@ -999,7 +999,7 @@ Private Function rekursiv(tx as string) as string
 
 End Function
 
-```
+`
 
 </details>
 
@@ -1053,7 +1053,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```main```](#main) : <small>  [Zeile 112] : ```        wert = subtrahieren(i, i - 1) ' Erklärung siehe @ Func!``` </small>
+- [`main`](#main) : <small>  [Zeile 112] : `        wert = subtrahieren(i, i - 1) ' Erklärung siehe @ Func!` </small>
 
 
 
@@ -1085,7 +1085,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```addieren```](#addieren) : <small>  [Zeile 77] : ```    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben``` </small>
+- [`addieren`](#addieren) : <small>  [Zeile 77] : `    subtrahieren = addieren(a, -b) ' Parameter b wird mit -1 multipliziert übergeben` </small>
 
 
 
@@ -1116,7 +1116,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function subtrahieren(a as integer, b as integer) as integer
 ' Anzahl der Referenzierungen im Modul: 1
 ' Anzahl weiterer internen Aufrufe : 1
@@ -1132,7 +1132,7 @@ Private Function subtrahieren(a as integer, b as integer) as integer
 
 end Function
 
-```
+`
 
 </details>
 

--- a/output_data/current_test.bas - Dokumentation.html
+++ b/output_data/current_test.bas - Dokumentation.html
@@ -177,7 +177,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 744] : ```                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 744] : `                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)` </small>
 
 
 
@@ -235,7 +235,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub InsertImageFromFileToCell(zeile As Integer, spalte As Integer, image_path As String, Optional fitTo As String = "Width")
 ' Private Sub InsertImageFromFileToCell(zeile As Integer, spalte As Integer, image_path As String)
 
@@ -265,7 +265,7 @@ Private Sub InsertImageFromFileToCell(zeile As Integer, spalte As Integer, image
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -313,7 +313,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 767] : ```    Call SeitenformatNextPosition(oSeite)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 767] : `    Call SeitenformatNextPosition(oSeite)` </small>
 
 
 
@@ -371,7 +371,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub SeitenformatNextPosition(oSeite As Seitenformat)
 ' Modifiziert die Attribute des Objektes so, dass die naechste Position in den Attributen gespeichert wird
 
@@ -391,7 +391,7 @@ Private Sub SeitenformatNextPosition(oSeite As Seitenformat)
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -495,13 +495,13 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub THIS_VERSION__1_17()
 ' Dummy-Methode, um Versionsnummer in MacroList anzeigen zu lassen...
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -549,7 +549,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```notengriffeErzeugen```](#notengriffeErzeugen) : <small>  [Zeile 1192] : ```        Call applyLayoutPrintArea(oSeite)``` </small>
+- [`notengriffeErzeugen`](#notengriffeErzeugen) : <small>  [Zeile 1192] : `        Call applyLayoutPrintArea(oSeite)` </small>
 
 
 
@@ -581,7 +581,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```getCountsOfColumnsToPrint```](#getCountsOfColumnsToPrint) : <small>  [Zeile 254] : ```    anzahlColumnsToPrint = getCountsOfColumnsToPrint(oSeite)``` </small>
+- [`getCountsOfColumnsToPrint`](#getCountsOfColumnsToPrint) : <small>  [Zeile 254] : `    anzahlColumnsToPrint = getCountsOfColumnsToPrint(oSeite)` </small>
 
 
 
@@ -614,7 +614,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Sub applyLayoutPrintArea(oSeite As Seitenformat)
     ' Legt den Druckbereich der einzelnen Seite fest, in Abhängigkeit der tatsaechlich vorhandenen Anzahl von Spalten:
 
@@ -639,7 +639,7 @@ Private Sub applyLayoutPrintArea(oSeite As Seitenformat)
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -688,7 +688,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```notengriffeErzeugen```](#notengriffeErzeugen) : <small>  [Zeile 1201] : ```    Call applyLayoutToAllPages(oSeite)``` </small>
+- [`notengriffeErzeugen`](#notengriffeErzeugen) : <small>  [Zeile 1201] : `    Call applyLayoutToAllPages(oSeite)` </small>
 
 
 
@@ -720,22 +720,22 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```applyLayoutToSinglePage```](#applyLayoutToSinglePage) : <small>  [Zeile 150] : ```        Call applyLayoutToSinglePage(ws, page, oSeite)``` </small>
+- [`applyLayoutToSinglePage`](#applyLayoutToSinglePage) : <small>  [Zeile 150] : `        Call applyLayoutToSinglePage(ws, page, oSeite)` </small>
 
 
-  - [```getCountsOfColumnsToPrint```](#getCountsOfColumnsToPrint) : <small>  [Zeile 179] : ```    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)``` </small>
-
-
-
-      - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
-
-  - [```mergeCells```](#mergeCells) : <small>  [Zeile 195] : ```    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)``` </small>
+  - [`getCountsOfColumnsToPrint`](#getCountsOfColumnsToPrint) : <small>  [Zeile 179] : `    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-  - [```mergeCells```](#mergeCells) : <small>  [Zeile 211] : ```    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)``` </small>
+  - [`mergeCells`](#mergeCells) : <small>  [Zeile 195] : `    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)` </small>
+
+
+
+      - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
+
+  - [`mergeCells`](#mergeCells) : <small>  [Zeile 211] : `    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)` </small>
 
 
 
@@ -771,7 +771,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Sub applyLayoutToAllPages(oSeite As Seitenformat)
     ' Durchlaeuft alle erstellten Tabellenblaetter und schleust durch zu einer Anwendungsfunktion, die wiederum  den Titel und andere Dinge in diese Blaetter  ein. Als oSeite wird das zuletzt-verwendete Objekt verwendet - benoetigt werden neben den ALLGEMEINEN UND KONSTANTEN Attributen nur die Angabe der pageNum als Gesamtseitenzahl.
     ' Zusaetzlich wird AUSSERHALB DES DRUCKBEREICHES auch ein Hyperlink zur Steuertabelle eingefuegt...
@@ -792,7 +792,7 @@ Private Sub applyLayoutToAllPages(oSeite As Seitenformat)
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -840,7 +840,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```applyLayoutToAllPages```](#applyLayoutToAllPages) : <small>  [Zeile 150] : ```        Call applyLayoutToSinglePage(ws, page, oSeite)``` </small>
+- [`applyLayoutToAllPages`](#applyLayoutToAllPages) : <small>  [Zeile 150] : `        Call applyLayoutToSinglePage(ws, page, oSeite)` </small>
 
 
 
@@ -872,19 +872,19 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```getCountsOfColumnsToPrint```](#getCountsOfColumnsToPrint) : <small>  [Zeile 179] : ```    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)``` </small>
+- [`getCountsOfColumnsToPrint`](#getCountsOfColumnsToPrint) : <small>  [Zeile 179] : `    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```mergeCells```](#mergeCells) : <small>  [Zeile 195] : ```    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)``` </small>
+- [`mergeCells`](#mergeCells) : <small>  [Zeile 195] : `    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```mergeCells```](#mergeCells) : <small>  [Zeile 211] : ```    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)``` </small>
+- [`mergeCells`](#mergeCells) : <small>  [Zeile 211] : `    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)` </small>
 
 
 
@@ -917,7 +917,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Sub applyLayoutToSinglePage(wsResult As Worksheet, thisPageNum As Integer, oSeite As Seitenformat)
     ' Zusaetzlich wird AUSSERHALB DES DRUCKBEREICHES auch ein Hyperlink zur Steuertabelle eingefuegt...
 
@@ -986,7 +986,7 @@ Private Sub applyLayoutToSinglePage(wsResult As Worksheet, thisPageNum As Intege
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -1034,7 +1034,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```notengriffeErzeugen```](#notengriffeErzeugen) : <small>  [Zeile 1191] : ```        Call erstelleKonvertierteSeite(startzeileSteuertabelle, oSeite)``` </small>
+- [`notengriffeErzeugen`](#notengriffeErzeugen) : <small>  [Zeile 1191] : `        Call erstelleKonvertierteSeite(startzeileSteuertabelle, oSeite)` </small>
 
 
 
@@ -1066,10 +1066,10 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```insertSheet```](#insertSheet) : <small>  [Zeile 662] : ```        Call insertSheet(oSeite.blattname & pageNum)``` </small>
+- [`insertSheet`](#insertSheet) : <small>  [Zeile 662] : `        Call insertSheet(oSeite.blattname & pageNum)` </small>
 
 
-  - [```existsSheetname```](#existsSheetname) : <small>  [Zeile 283] : ```        If existsSheetname(sheetname) = False Then``` </small>
+  - [`existsSheetname`](#existsSheetname) : <small>  [Zeile 283] : `        If existsSheetname(sheetname) = False Then` </small>
 
 
 
@@ -1079,19 +1079,19 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 677] : ```            If konvertiereZeile(zeileSteuertabelle, oSeite) = False Then``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 677] : `            If konvertiereZeile(zeileSteuertabelle, oSeite) = False Then` </small>
 
 
-  - [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 723] : ```                    oReplacer = getReplacerPre1(stichwort)``` </small>
+  - [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 723] : `                    oReplacer = getReplacerPre1(stichwort)` </small>
 
 
-      - [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+      - [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-      - [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+      - [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -1101,19 +1101,19 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```getReplacerPre2```](#getReplacerPre2) : <small>  [Zeile 725] : ```                    oReplacer = getReplacerPre2(stichwort)``` </small>
+  - [`getReplacerPre2`](#getReplacerPre2) : <small>  [Zeile 725] : `                    oReplacer = getReplacerPre2(stichwort)` </small>
 
 
-      - [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 445] : ```    getReplacerPre2 = getReplacerPre1(stichwort)``` </small>
+      - [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 445] : `    getReplacerPre2 = getReplacerPre1(stichwort)` </small>
 
 
-        - [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+        - [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
           - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-        - [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+        - [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -1127,38 +1127,38 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```getReplacerNote```](#getReplacerNote) : <small>  [Zeile 727] : ```                    oReplacer = getReplacerNote(stichwort)``` </small>
+  - [`getReplacerNote`](#getReplacerNote) : <small>  [Zeile 727] : `                    oReplacer = getReplacerNote(stichwort)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```getReplacerCount```](#getReplacerCount) : <small>  [Zeile 729] : ```                    oReplacer = getReplacerCount(stichwort)``` </small>
+  - [`getReplacerCount`](#getReplacerCount) : <small>  [Zeile 729] : `                    oReplacer = getReplacerCount(stichwort)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```getReplacerPost```](#getReplacerPost) : <small>  [Zeile 731] : ```                    oReplacer = getReplacerPost(stichwort)``` </small>
+  - [`getReplacerPost`](#getReplacerPost) : <small>  [Zeile 731] : `                    oReplacer = getReplacerPost(stichwort)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```getReplacerEmpty```](#getReplacerEmpty) : <small>  [Zeile 733] : ```                    oReplacer = getReplacerEmpty()``` </small>
+  - [`getReplacerEmpty`](#getReplacerEmpty) : <small>  [Zeile 733] : `                    oReplacer = getReplacerEmpty()` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```getFilePath```](#getFilePath) : <small>  [Zeile 742] : ```                pathImage = getFilePath(oReplacer.value)``` </small>
+  - [`getFilePath`](#getFilePath) : <small>  [Zeile 742] : `                pathImage = getFilePath(oReplacer.value)` </small>
 
 
-      - [```getFilePath```](#getFilePath) : <small>  [Zeile 366] : ```    getFilePath = getFilePath(ERROR_FILENAME)``` </small>
+      - [`getFilePath`](#getFilePath) : <small>  [Zeile 366] : `    getFilePath = getFilePath(ERROR_FILENAME)` </small>
 
 
         - <small> *... recursivly calls itself under certain conditions ...* </small> 
@@ -1168,25 +1168,25 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```InsertImageFromFileToCell```](#InsertImageFromFileToCell) : <small>  [Zeile 744] : ```                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)``` </small>
+  - [`InsertImageFromFileToCell`](#InsertImageFromFileToCell) : <small>  [Zeile 744] : `                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-  - [```getTypeOfFollowingSeperatorLine```](#getTypeOfFollowingSeperatorLine) : <small>  [Zeile 757] : ```    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)``` </small>
+  - [`getTypeOfFollowingSeperatorLine`](#getTypeOfFollowingSeperatorLine) : <small>  [Zeile 757] : `    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-  - [```insertFrameLineBelow```](#insertFrameLineBelow) : <small>  [Zeile 762] : ```        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))``` </small>
+  - [`insertFrameLineBelow`](#insertFrameLineBelow) : <small>  [Zeile 762] : `        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-  - [```SeitenformatNextPosition```](#SeitenformatNextPosition) : <small>  [Zeile 767] : ```    Call SeitenformatNextPosition(oSeite)``` </small>
+  - [`SeitenformatNextPosition`](#SeitenformatNextPosition) : <small>  [Zeile 767] : `    Call SeitenformatNextPosition(oSeite)` </small>
 
 
 
@@ -1221,7 +1221,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Sub erstelleKonvertierteSeite(startzeileSteuertabelle As Integer, oSeite As Seitenformat)
     ' Erstelle neues TBB und wende Atrriubte an
 
@@ -1259,7 +1259,7 @@ Private Sub erstelleKonvertierteSeite(startzeileSteuertabelle As Integer, oSeite
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -1307,7 +1307,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```notengriffeErzeugen```](#notengriffeErzeugen) : <small>  [Zeile 1172] : ```    Call init``` </small>
+- [`notengriffeErzeugen`](#notengriffeErzeugen) : <small>  [Zeile 1172] : `    Call init` </small>
 
 
 
@@ -1365,7 +1365,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub init()
     ' Parameter fuer modulweite Variablen laden
 
@@ -1381,7 +1381,7 @@ Private Sub init()
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -1429,7 +1429,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 762] : ```        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 762] : `        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))` </small>
 
 
 
@@ -1487,7 +1487,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub insertFrameLineBelow(rowAbove As Integer, oSeite As Seitenformat, dashed As Boolean)
     ' Fuegt die unteren Rahmenlinien aller Zellen dieser Zeile im Subspaltenbereich ein
 
@@ -1515,7 +1515,7 @@ Private Sub insertFrameLineBelow(rowAbove As Integer, oSeite As Seitenformat, da
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -1563,7 +1563,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```erstelleKonvertierteSeite```](#erstelleKonvertierteSeite) : <small>  [Zeile 662] : ```        Call insertSheet(oSeite.blattname & pageNum)``` </small>
+- [`erstelleKonvertierteSeite`](#erstelleKonvertierteSeite) : <small>  [Zeile 662] : `        Call insertSheet(oSeite.blattname & pageNum)` </small>
 
 
 
@@ -1595,7 +1595,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```existsSheetname```](#existsSheetname) : <small>  [Zeile 283] : ```        If existsSheetname(sheetname) = False Then``` </small>
+- [`existsSheetname`](#existsSheetname) : <small>  [Zeile 283] : `        If existsSheetname(sheetname) = False Then` </small>
 
 
 
@@ -1627,7 +1627,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Sub insertSheet(sheetname As String)
     ' Fuegt ein neues Tabellenblatt hinzu mit dem uebergebenen Namen und modifiziert den Tabellenblattnamen, sofern dieser bereits existiert
 
@@ -1651,7 +1651,7 @@ Private Sub insertSheet(sheetname As String)
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -1699,9 +1699,9 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```applyLayoutToSinglePage```](#applyLayoutToSinglePage) : <small>  [Zeile 195] : ```    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)``` </small>
+- [`applyLayoutToSinglePage`](#applyLayoutToSinglePage) : <small>  [Zeile 195] : `    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)` </small>
 
-- [```applyLayoutToSinglePage```](#applyLayoutToSinglePage) : <small>  [Zeile 211] : ```    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)``` </small>
+- [`applyLayoutToSinglePage`](#applyLayoutToSinglePage) : <small>  [Zeile 211] : `    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)` </small>
 
 
 
@@ -1759,7 +1759,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub mergeCells(ws As Worksheet, lineFrom As Integer, columnFrom As Integer, lineTo As Integer, columnTo As Integer)
     ' Verbindet den uebergebenen Zellbereich
 
@@ -1774,7 +1774,7 @@ Private Sub mergeCells(ws As Worksheet, lineFrom As Integer, columnFrom As Integ
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -1824,7 +1824,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+- [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
@@ -1882,7 +1882,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub modifyReplacerIfSonderzeichen(oReplacer As Replacer)
     ' Prueft, ob das Stichwort einem definierten Sonderzeichen entspricht.
     ' Jedes definierte Sonderzeichen erhaelt ein expliziten Bild-Dateiname als Verknuepfung (ohne Dateiendung hier.)
@@ -1923,7 +1923,7 @@ Private Sub modifyReplacerIfSonderzeichen(oReplacer As Replacer)
 ' End Function
 End Sub
 
-```
+`
 
 </details>
 
@@ -1973,7 +1973,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+- [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -2031,7 +2031,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Sub modifyReplacerIfTaktwechsel(oReplacer As Replacer)
     ' Prueft, ob das Stichwort einem Taktartwechsel entspricht.
     ' Je nach Taktart wird das uebergebene Replacer-Objekt inplace modifiziert und zurueckgegeben (mal wird ein Bild gewuenscht, mal nciht...)
@@ -2073,7 +2073,7 @@ Private Sub modifyReplacerIfTaktwechsel(oReplacer As Replacer)
     Next i
 End Sub
 
-```
+`
 
 </details>
 
@@ -2150,33 +2150,33 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```init```](#init) : <small>  [Zeile 1172] : ```    Call init``` </small>
+- [`init`](#init) : <small>  [Zeile 1172] : `    Call init` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```addSeitenformat```](#addSeitenformat) : <small>  [Zeile 1183] : ```        oSeite = addSeitenformat(startzeileSteuertabelle)``` </small>
+- [`addSeitenformat`](#addSeitenformat) : <small>  [Zeile 1183] : `        oSeite = addSeitenformat(startzeileSteuertabelle)` </small>
 
 
-  - [```newSeitenformat```](#newSeitenformat) : <small>  [Zeile 970] : ```    oFormat = newSeitenformat()``` </small>
+  - [`newSeitenformat`](#newSeitenformat) : <small>  [Zeile 970] : `    oFormat = newSeitenformat()` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```identifyLastRow```](#identifyLastRow) : <small>  [Zeile 980] : ```    letzteZeileSteuertabelle = identifyLastRow(startzeileSteuertabelle, oFormat.maxAnzahlEintraege)``` </small>
+  - [`identifyLastRow`](#identifyLastRow) : <small>  [Zeile 980] : `    letzteZeileSteuertabelle = identifyLastRow(startzeileSteuertabelle, oFormat.maxAnzahlEintraege)` </small>
 
 
-    - [```newSeitenformat```](#newSeitenformat) : <small>  [Zeile 876] : ```    tempObj = newSeitenformat(readParameters:=False)``` </small>
+    - [`newSeitenformat`](#newSeitenformat) : <small>  [Zeile 876] : `    tempObj = newSeitenformat(readParameters:=False)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-    - [```areaEmpty```](#areaEmpty) : <small>  [Zeile 882] : ```        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then``` </small>
+    - [`areaEmpty`](#areaEmpty) : <small>  [Zeile 882] : `        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then` </small>
 
 
 
@@ -2191,13 +2191,13 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```erstelleKonvertierteSeite```](#erstelleKonvertierteSeite) : <small>  [Zeile 1191] : ```        Call erstelleKonvertierteSeite(startzeileSteuertabelle, oSeite)``` </small>
+- [`erstelleKonvertierteSeite`](#erstelleKonvertierteSeite) : <small>  [Zeile 1191] : `        Call erstelleKonvertierteSeite(startzeileSteuertabelle, oSeite)` </small>
 
 
-  - [```insertSheet```](#insertSheet) : <small>  [Zeile 662] : ```        Call insertSheet(oSeite.blattname & pageNum)``` </small>
+  - [`insertSheet`](#insertSheet) : <small>  [Zeile 662] : `        Call insertSheet(oSeite.blattname & pageNum)` </small>
 
 
-    - [```existsSheetname```](#existsSheetname) : <small>  [Zeile 283] : ```        If existsSheetname(sheetname) = False Then``` </small>
+    - [`existsSheetname`](#existsSheetname) : <small>  [Zeile 283] : `        If existsSheetname(sheetname) = False Then` </small>
 
 
 
@@ -2207,19 +2207,19 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-  - [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 677] : ```            If konvertiereZeile(zeileSteuertabelle, oSeite) = False Then``` </small>
+  - [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 677] : `            If konvertiereZeile(zeileSteuertabelle, oSeite) = False Then` </small>
 
 
-    - [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 723] : ```                    oReplacer = getReplacerPre1(stichwort)``` </small>
+    - [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 723] : `                    oReplacer = getReplacerPre1(stichwort)` </small>
 
 
-        - [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+        - [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
           - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-        - [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+        - [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -2229,19 +2229,19 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-    - [```getReplacerPre2```](#getReplacerPre2) : <small>  [Zeile 725] : ```                    oReplacer = getReplacerPre2(stichwort)``` </small>
+    - [`getReplacerPre2`](#getReplacerPre2) : <small>  [Zeile 725] : `                    oReplacer = getReplacerPre2(stichwort)` </small>
 
 
-        - [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 445] : ```    getReplacerPre2 = getReplacerPre1(stichwort)``` </small>
+        - [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 445] : `    getReplacerPre2 = getReplacerPre1(stichwort)` </small>
 
 
-          - [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+          - [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
             - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-          - [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+          - [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -2255,38 +2255,38 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-    - [```getReplacerNote```](#getReplacerNote) : <small>  [Zeile 727] : ```                    oReplacer = getReplacerNote(stichwort)``` </small>
+    - [`getReplacerNote`](#getReplacerNote) : <small>  [Zeile 727] : `                    oReplacer = getReplacerNote(stichwort)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-    - [```getReplacerCount```](#getReplacerCount) : <small>  [Zeile 729] : ```                    oReplacer = getReplacerCount(stichwort)``` </small>
+    - [`getReplacerCount`](#getReplacerCount) : <small>  [Zeile 729] : `                    oReplacer = getReplacerCount(stichwort)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-    - [```getReplacerPost```](#getReplacerPost) : <small>  [Zeile 731] : ```                    oReplacer = getReplacerPost(stichwort)``` </small>
+    - [`getReplacerPost`](#getReplacerPost) : <small>  [Zeile 731] : `                    oReplacer = getReplacerPost(stichwort)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-    - [```getReplacerEmpty```](#getReplacerEmpty) : <small>  [Zeile 733] : ```                    oReplacer = getReplacerEmpty()``` </small>
+    - [`getReplacerEmpty`](#getReplacerEmpty) : <small>  [Zeile 733] : `                    oReplacer = getReplacerEmpty()` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-    - [```getFilePath```](#getFilePath) : <small>  [Zeile 742] : ```                pathImage = getFilePath(oReplacer.value)``` </small>
+    - [`getFilePath`](#getFilePath) : <small>  [Zeile 742] : `                pathImage = getFilePath(oReplacer.value)` </small>
 
 
-        - [```getFilePath```](#getFilePath) : <small>  [Zeile 366] : ```    getFilePath = getFilePath(ERROR_FILENAME)``` </small>
+        - [`getFilePath`](#getFilePath) : <small>  [Zeile 366] : `    getFilePath = getFilePath(ERROR_FILENAME)` </small>
 
 
           - <small> *... recursivly calls itself under certain conditions ...* </small> 
@@ -2296,25 +2296,25 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-    - [```InsertImageFromFileToCell```](#InsertImageFromFileToCell) : <small>  [Zeile 744] : ```                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)``` </small>
+    - [`InsertImageFromFileToCell`](#InsertImageFromFileToCell) : <small>  [Zeile 744] : `                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-    - [```getTypeOfFollowingSeperatorLine```](#getTypeOfFollowingSeperatorLine) : <small>  [Zeile 757] : ```    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)``` </small>
+    - [`getTypeOfFollowingSeperatorLine`](#getTypeOfFollowingSeperatorLine) : <small>  [Zeile 757] : `    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-    - [```insertFrameLineBelow```](#insertFrameLineBelow) : <small>  [Zeile 762] : ```        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))``` </small>
+    - [`insertFrameLineBelow`](#insertFrameLineBelow) : <small>  [Zeile 762] : `        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-    - [```SeitenformatNextPosition```](#SeitenformatNextPosition) : <small>  [Zeile 767] : ```    Call SeitenformatNextPosition(oSeite)``` </small>
+    - [`SeitenformatNextPosition`](#SeitenformatNextPosition) : <small>  [Zeile 767] : `    Call SeitenformatNextPosition(oSeite)` </small>
 
 
 
@@ -2327,10 +2327,10 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```applyLayoutPrintArea```](#applyLayoutPrintArea) : <small>  [Zeile 1192] : ```        Call applyLayoutPrintArea(oSeite)``` </small>
+- [`applyLayoutPrintArea`](#applyLayoutPrintArea) : <small>  [Zeile 1192] : `        Call applyLayoutPrintArea(oSeite)` </small>
 
 
-  - [```getCountsOfColumnsToPrint```](#getCountsOfColumnsToPrint) : <small>  [Zeile 254] : ```    anzahlColumnsToPrint = getCountsOfColumnsToPrint(oSeite)``` </small>
+  - [`getCountsOfColumnsToPrint`](#getCountsOfColumnsToPrint) : <small>  [Zeile 254] : `    anzahlColumnsToPrint = getCountsOfColumnsToPrint(oSeite)` </small>
 
 
 
@@ -2341,25 +2341,25 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```applyLayoutToAllPages```](#applyLayoutToAllPages) : <small>  [Zeile 1201] : ```    Call applyLayoutToAllPages(oSeite)``` </small>
+- [`applyLayoutToAllPages`](#applyLayoutToAllPages) : <small>  [Zeile 1201] : `    Call applyLayoutToAllPages(oSeite)` </small>
 
 
-  - [```applyLayoutToSinglePage```](#applyLayoutToSinglePage) : <small>  [Zeile 150] : ```        Call applyLayoutToSinglePage(ws, page, oSeite)``` </small>
+  - [`applyLayoutToSinglePage`](#applyLayoutToSinglePage) : <small>  [Zeile 150] : `        Call applyLayoutToSinglePage(ws, page, oSeite)` </small>
 
 
-    - [```getCountsOfColumnsToPrint```](#getCountsOfColumnsToPrint) : <small>  [Zeile 179] : ```    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)``` </small>
-
-
-
-        - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
-
-    - [```mergeCells```](#mergeCells) : <small>  [Zeile 195] : ```    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)``` </small>
+    - [`getCountsOfColumnsToPrint`](#getCountsOfColumnsToPrint) : <small>  [Zeile 179] : `    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-    - [```mergeCells```](#mergeCells) : <small>  [Zeile 211] : ```    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)``` </small>
+    - [`mergeCells`](#mergeCells) : <small>  [Zeile 195] : `    Call mergeCells(wsResult, titelZeile, titelSpalte, titelZeile, anzahlColumnsToMerge)` </small>
+
+
+
+        - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
+
+    - [`mergeCells`](#mergeCells) : <small>  [Zeile 211] : `    Call mergeCells(wsResult, seitenangabeZeile, seitenangabeSpalte, seitenangabeZeile, anzahlColumnsToMerge)` </small>
 
 
 
@@ -2373,7 +2373,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```printLastSheetsAsPdf```](#printLastSheetsAsPdf) : <small>  [Zeile 1210] : ```        Call printLastSheetsAsPdf(pageNum)``` </small>
+- [`printLastSheetsAsPdf`](#printLastSheetsAsPdf) : <small>  [Zeile 1210] : `        Call printLastSheetsAsPdf(pageNum)` </small>
 
 
 
@@ -2406,7 +2406,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Public Sub notengriffeErzeugen()
 
     ' Initialisieren der modulweiten Variablen (Worksheets usw...)
@@ -2457,7 +2457,7 @@ Public Sub notengriffeErzeugen()
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -2505,7 +2505,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```notengriffeErzeugen```](#notengriffeErzeugen) : <small>  [Zeile 1210] : ```        Call printLastSheetsAsPdf(pageNum)``` </small>
+- [`notengriffeErzeugen`](#notengriffeErzeugen) : <small>  [Zeile 1210] : `        Call printLastSheetsAsPdf(pageNum)` </small>
 
 
 
@@ -2563,7 +2563,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Sub printLastSheetsAsPdf(anzahlSheets As Integer)
 ' Speichert die hintersten (ERgebnis-Tabellenblaetter) als PDF ab, inkl. Skalierung auf eine Seite der Spalten.
 
@@ -2641,7 +2641,7 @@ Sub printLastSheetsAsPdf(anzahlSheets As Integer)
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -2718,7 +2718,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```getProjectTitle```](#getProjectTitle) : <small>  [Zeile 111] : ```    MsgBox "Alle generierten Tabellenblaetter wurden geloescht. Dieser Vorgang kann nicht rueckgaengig gemacht werden! (--> falls Falsch ginge ggf. schliessen ohne speichern, sofern alle relevanten Modifikationen vorab gespeichert wurden...)", vbOK, getProjectTitle()``` </small>
+- [`getProjectTitle`](#getProjectTitle) : <small>  [Zeile 111] : `    MsgBox "Alle generierten Tabellenblaetter wurden geloescht. Dieser Vorgang kann nicht rueckgaengig gemacht werden! (--> falls Falsch ginge ggf. schliessen ohne speichern, sofern alle relevanten Modifikationen vorab gespeichert wurden...)", vbOK, getProjectTitle()` </small>
 
 
 
@@ -2751,7 +2751,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Sub resetWorkbook()
 
     If InputBox("Sollen alle generierten Tabellenblaetter UNWIDERUFLICH ENTFERNT werden? (dann eingabe von: 'y', sonst was beliebiges anderes)", getProjectTitle()) <> "y" Then
@@ -2780,7 +2780,7 @@ Sub resetWorkbook()
 
 End Sub
 
-```
+`
 
 </details>
 
@@ -2836,7 +2836,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```notengriffeErzeugen```](#notengriffeErzeugen) : <small>  [Zeile 1183] : ```        oSeite = addSeitenformat(startzeileSteuertabelle)``` </small>
+- [`notengriffeErzeugen`](#notengriffeErzeugen) : <small>  [Zeile 1183] : `        oSeite = addSeitenformat(startzeileSteuertabelle)` </small>
 
 
 
@@ -2868,23 +2868,23 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```newSeitenformat```](#newSeitenformat) : <small>  [Zeile 970] : ```    oFormat = newSeitenformat()``` </small>
+- [`newSeitenformat`](#newSeitenformat) : <small>  [Zeile 970] : `    oFormat = newSeitenformat()` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```identifyLastRow```](#identifyLastRow) : <small>  [Zeile 980] : ```    letzteZeileSteuertabelle = identifyLastRow(startzeileSteuertabelle, oFormat.maxAnzahlEintraege)``` </small>
+- [`identifyLastRow`](#identifyLastRow) : <small>  [Zeile 980] : `    letzteZeileSteuertabelle = identifyLastRow(startzeileSteuertabelle, oFormat.maxAnzahlEintraege)` </small>
 
 
-  - [```newSeitenformat```](#newSeitenformat) : <small>  [Zeile 876] : ```    tempObj = newSeitenformat(readParameters:=False)``` </small>
+  - [`newSeitenformat`](#newSeitenformat) : <small>  [Zeile 876] : `    tempObj = newSeitenformat(readParameters:=False)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-  - [```areaEmpty```](#areaEmpty) : <small>  [Zeile 882] : ```        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then``` </small>
+  - [`areaEmpty`](#areaEmpty) : <small>  [Zeile 882] : `        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then` </small>
 
 
 
@@ -2921,7 +2921,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function addSeitenformat(startzeileSteuertabelle As Integer) As Seitenformat
 ' Erstellt ein Objekt des Typs Seitenformat und initialisiert die Konstanten Werte sowie zusaetzlich berechnete.
 ' Berechnet alle Attribute, das Obj wird zurück gegeben, auf Grundlage von diesem kann ein neues Blatt genereiert werden.
@@ -2964,7 +2964,7 @@ Private Function addSeitenformat(startzeileSteuertabelle As Integer) As Seitenfo
 
 End Function
 
-```
+`
 
 </details>
 
@@ -3015,7 +3015,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```identifyLastRow```](#identifyLastRow) : <small>  [Zeile 882] : ```        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then``` </small>
+- [`identifyLastRow`](#identifyLastRow) : <small>  [Zeile 882] : `        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then` </small>
 
 
 
@@ -3073,7 +3073,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function areaEmpty(ws As Worksheet, lineFrom As Integer, columnFrom As Integer, lineTo As Integer, columnTo As Integer)
     ' Prueft einen Bereich auf leere Zellen.
     ' Rueckgabewerte:
@@ -3103,7 +3103,7 @@ Private Function areaEmpty(ws As Worksheet, lineFrom As Integer, columnFrom As I
 
     End Function
 
-```
+`
 
 </details>
 
@@ -3150,7 +3150,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```insertSheet```](#insertSheet) : <small>  [Zeile 283] : ```        If existsSheetname(sheetname) = False Then``` </small>
+- [`insertSheet`](#insertSheet) : <small>  [Zeile 283] : `        If existsSheetname(sheetname) = False Then` </small>
 
 
 
@@ -3208,7 +3208,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function existsSheetname(name As String) As Boolean
 
     Dim ws As Worksheet
@@ -3226,7 +3226,7 @@ Private Function existsSheetname(name As String) As Boolean
 
 End Function
 
-```
+`
 
 </details>
 
@@ -3275,9 +3275,9 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```applyLayoutToSinglePage```](#applyLayoutToSinglePage) : <small>  [Zeile 179] : ```    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)``` </small>
+- [`applyLayoutToSinglePage`](#applyLayoutToSinglePage) : <small>  [Zeile 179] : `    anzahlColumnsToMerge = getCountsOfColumnsToPrint(oSeite)` </small>
 
-- [```applyLayoutPrintArea```](#applyLayoutPrintArea) : <small>  [Zeile 254] : ```    anzahlColumnsToPrint = getCountsOfColumnsToPrint(oSeite)``` </small>
+- [`applyLayoutPrintArea`](#applyLayoutPrintArea) : <small>  [Zeile 254] : `    anzahlColumnsToPrint = getCountsOfColumnsToPrint(oSeite)` </small>
 
 
 
@@ -3335,7 +3335,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Function getCountsOfColumnsToPrint(oSeite As Seitenformat) As Integer
     ' Berechnet die tatsaechliche Anzahl der zu druckenden Spalten
     ' Dafuer wird die letzte Spalte abgezogen, weil wg. Blattrand keine zusaetzliche Luft erforderlich ist:
@@ -3344,7 +3344,7 @@ Function getCountsOfColumnsToPrint(oSeite As Seitenformat) As Integer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -3393,9 +3393,9 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```getFilePath```](#getFilePath) : <small>  [Zeile 366] : ```    getFilePath = getFilePath(ERROR_FILENAME)``` </small>
+- [`getFilePath`](#getFilePath) : <small>  [Zeile 366] : `    getFilePath = getFilePath(ERROR_FILENAME)` </small>
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 742] : ```                pathImage = getFilePath(oReplacer.value)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 742] : `                pathImage = getFilePath(oReplacer.value)` </small>
 
 
 
@@ -3427,7 +3427,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```getFilePath```](#getFilePath) : <small>  [Zeile 366] : ```    getFilePath = getFilePath(ERROR_FILENAME)``` </small>
+- [`getFilePath`](#getFilePath) : <small>  [Zeile 366] : `    getFilePath = getFilePath(ERROR_FILENAME)` </small>
 
 
   - <small> *... recursivly calls itself under certain conditions ...* </small> 
@@ -3459,7 +3459,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function getFilePath(stichwort As String)
     ' Generiert einen Path zur Bilddatei basierend auf einem Stichwort.
     ' Sofern es keine passende Datei gibt, wird ein Platzhalter-Bild referenziert, durch das ein FEHLER verdeutlcihet wird.
@@ -3492,7 +3492,7 @@ Private Function getFilePath(stichwort As String)
 
 End Function
 
-```
+`
 
 </details>
 
@@ -3597,7 +3597,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function getModifiedKeyIfTaktwechsel(stichwort As String) As String
     ' Prueft, ob das Stichwort einem Taktartwechsel entspricht.
     ' Dazu werden konkrete Stichworte geprueftund durch ein alternativ-stichwort fuer einen Dateinamen ersetzt zurueckgegeben.
@@ -3626,7 +3626,7 @@ Private Function getModifiedKeyIfTaktwechsel(stichwort As String) As String
 
 End Function
 
-```
+`
 
 </details>
 
@@ -3673,7 +3673,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```resetWorkbook```](#resetWorkbook) : <small>  [Zeile 111] : ```    MsgBox "Alle generierten Tabellenblaetter wurden geloescht. Dieser Vorgang kann nicht rueckgaengig gemacht werden! (--> falls Falsch ginge ggf. schliessen ohne speichern, sofern alle relevanten Modifikationen vorab gespeichert wurden...)", vbOK, getProjectTitle()``` </small>
+- [`resetWorkbook`](#resetWorkbook) : <small>  [Zeile 111] : `    MsgBox "Alle generierten Tabellenblaetter wurden geloescht. Dieser Vorgang kann nicht rueckgaengig gemacht werden! (--> falls Falsch ginge ggf. schliessen ohne speichern, sofern alle relevanten Modifikationen vorab gespeichert wurden...)", vbOK, getProjectTitle()` </small>
 
 
 
@@ -3731,14 +3731,14 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Function getProjectTitle() As String
 
     getProjectTitle = "Notengriff-Converter"
 
 End Function
 
-```
+`
 
 </details>
 
@@ -3786,7 +3786,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 729] : ```                    oReplacer = getReplacerCount(stichwort)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 729] : `                    oReplacer = getReplacerCount(stichwort)` </small>
 
 
 
@@ -3844,7 +3844,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function getReplacerCount(stichwort As String) As Replacer
     ' Prueft das Stichwort fuer diese spezielle Spalte/ das Attribut und gibt darauf basierend eine ZEichenkette als Replacer zurueck. Diese Zeichenkette entspricht entweder dem Stichwort (Text uebernehmen) oder dem Dateipfad zu einem Bilddatei.
 
@@ -3861,7 +3861,7 @@ Private Function getReplacerCount(stichwort As String) As Replacer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -3909,7 +3909,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 733] : ```                    oReplacer = getReplacerEmpty()``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 733] : `                    oReplacer = getReplacerEmpty()` </small>
 
 
 
@@ -3967,7 +3967,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function getReplacerEmpty() As Replacer
     ' Gibt leeren Replacer zurueck
 
@@ -3981,7 +3981,7 @@ Private Function getReplacerEmpty() As Replacer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -4029,7 +4029,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 727] : ```                    oReplacer = getReplacerNote(stichwort)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 727] : `                    oReplacer = getReplacerNote(stichwort)` </small>
 
 
 
@@ -4087,7 +4087,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function getReplacerNote(stichwort As String) As Replacer
     ' Prueft das Stichwort fuer diese spezielle Spalte/ das Attribut und gibt darauf basierend eine ZEichenkette als Replacer zurueck. Diese Zeichenkette entspricht entweder dem Stichwort (Text uebernehmen) oder dem Dateipfad zu einem Bilddatei.
 
@@ -4117,7 +4117,7 @@ Private Function getReplacerNote(stichwort As String) As Replacer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -4165,7 +4165,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 731] : ```                    oReplacer = getReplacerPost(stichwort)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 731] : `                    oReplacer = getReplacerPost(stichwort)` </small>
 
 
 
@@ -4223,7 +4223,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function getReplacerPost(stichwort As String) As Replacer
     ' Prueft das Stichwort fuer diese spezielle Spalte/ das Attribut und gibt darauf basierend eine ZEichenkette als Replacer zurueck. Diese Zeichenkette entspricht entweder dem Stichwort (Text uebernehmen) oder dem Dateipfad zu einem Bilddatei.
 
@@ -4238,7 +4238,7 @@ Private Function getReplacerPost(stichwort As String) As Replacer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -4286,9 +4286,9 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```getReplacerPre2```](#getReplacerPre2) : <small>  [Zeile 445] : ```    getReplacerPre2 = getReplacerPre1(stichwort)``` </small>
+- [`getReplacerPre2`](#getReplacerPre2) : <small>  [Zeile 445] : `    getReplacerPre2 = getReplacerPre1(stichwort)` </small>
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 723] : ```                    oReplacer = getReplacerPre1(stichwort)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 723] : `                    oReplacer = getReplacerPre1(stichwort)` </small>
 
 
 
@@ -4320,13 +4320,13 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+- [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+- [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -4358,7 +4358,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function getReplacerPre1(stichwort As String) As Replacer
     ' Prueft das Stichwort fuer diese spezielle Spalte/ das Attribut und gibt darauf basierend eine ZEichenkette als Replacer zurueck. Diese Zeichenkette entspricht entweder dem Stichwort (Text uebernehmen) oder dem Dateipfad zu einem Bilddatei.
 
@@ -4420,7 +4420,7 @@ Private Function getReplacerPre1(stichwort As String) As Replacer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -4468,7 +4468,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 725] : ```                    oReplacer = getReplacerPre2(stichwort)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 725] : `                    oReplacer = getReplacerPre2(stichwort)` </small>
 
 
 
@@ -4500,16 +4500,16 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 445] : ```    getReplacerPre2 = getReplacerPre1(stichwort)``` </small>
+- [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 445] : `    getReplacerPre2 = getReplacerPre1(stichwort)` </small>
 
 
-  - [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+  - [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-  - [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+  - [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -4545,7 +4545,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function getReplacerPre2(stichwort As String) As Replacer
     ' Prueft das Stichwort fuer diese spezielle Spalte/ das Attribut und gibt darauf basierend eine ZEichenkette als Replacer zurueck. Diese Zeichenkette entspricht entweder dem Stichwort (Text uebernehmen) oder dem Dateipfad zu einem Bilddatei.
 
@@ -4554,7 +4554,7 @@ Private Function getReplacerPre2(stichwort As String) As Replacer
 
 End Function
 
-```
+`
 
 </details>
 
@@ -4604,7 +4604,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```konvertiereZeile```](#konvertiereZeile) : <small>  [Zeile 757] : ```    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)``` </small>
+- [`konvertiereZeile`](#konvertiereZeile) : <small>  [Zeile 757] : `    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)` </small>
 
 
 
@@ -4662,7 +4662,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function getTypeOfFollowingSeperatorLine(lastRowNumber As Integer, oSeite As Seitenformat) As Integer
 ' returns 0 falls kein eLinie folgt
 ' returns 1 falls durchgezogene Linie folgt
@@ -4693,7 +4693,7 @@ Private Function getTypeOfFollowingSeperatorLine(lastRowNumber As Integer, oSeit
 
 End Function
 
-```
+`
 
 </details>
 
@@ -4742,7 +4742,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```addSeitenformat```](#addSeitenformat) : <small>  [Zeile 980] : ```    letzteZeileSteuertabelle = identifyLastRow(startzeileSteuertabelle, oFormat.maxAnzahlEintraege)``` </small>
+- [`addSeitenformat`](#addSeitenformat) : <small>  [Zeile 980] : `    letzteZeileSteuertabelle = identifyLastRow(startzeileSteuertabelle, oFormat.maxAnzahlEintraege)` </small>
 
 
 
@@ -4774,13 +4774,13 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```newSeitenformat```](#newSeitenformat) : <small>  [Zeile 876] : ```    tempObj = newSeitenformat(readParameters:=False)``` </small>
+- [`newSeitenformat`](#newSeitenformat) : <small>  [Zeile 876] : `    tempObj = newSeitenformat(readParameters:=False)` </small>
 
 
 
   - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```areaEmpty```](#areaEmpty) : <small>  [Zeile 882] : ```        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then``` </small>
+- [`areaEmpty`](#areaEmpty) : <small>  [Zeile 882] : `        If Not areaEmpty(wsTodo, zeile, tempObj.excelStartSpaltenNr, zeile, tempObj.excelStartSpaltenNr + tempObj.anzahlSubSpaltenProSpalte - 1) Then` </small>
 
 
 
@@ -4813,7 +4813,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function identifyLastRow(startzeile As Integer, maxZeilen As Integer) As Integer
     ' Liesst die STB ausgehend ab startzeile aus bis dass die Anzahl maxZeilen abgearbeitet wurde. Pro Zeile wird sich die Zeilennummer gemerkt, sofern Inhalt vorhanden ist.
     ' Ziel davon ist, dass man so erkennt, wenn die letzten n zeilen nur freizeilen sind (um manuell einen seitenumbruch zu generieren), oder ob nur etwas abstand dadurch generiert werden sollte...
@@ -4839,7 +4839,7 @@ Private Function identifyLastRow(startzeile As Integer, maxZeilen As Integer) As
 
 End Function
 
-```
+`
 
 </details>
 
@@ -4892,7 +4892,7 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```erstelleKonvertierteSeite```](#erstelleKonvertierteSeite) : <small>  [Zeile 677] : ```            If konvertiereZeile(zeileSteuertabelle, oSeite) = False Then``` </small>
+- [`erstelleKonvertierteSeite`](#erstelleKonvertierteSeite) : <small>  [Zeile 677] : `            If konvertiereZeile(zeileSteuertabelle, oSeite) = False Then` </small>
 
 
 
@@ -4924,16 +4924,16 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 
 
-- [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 723] : ```                    oReplacer = getReplacerPre1(stichwort)``` </small>
+- [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 723] : `                    oReplacer = getReplacerPre1(stichwort)` </small>
 
 
-    - [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+    - [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
       - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-    - [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+    - [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -4943,19 +4943,19 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```getReplacerPre2```](#getReplacerPre2) : <small>  [Zeile 725] : ```                    oReplacer = getReplacerPre2(stichwort)``` </small>
+- [`getReplacerPre2`](#getReplacerPre2) : <small>  [Zeile 725] : `                    oReplacer = getReplacerPre2(stichwort)` </small>
 
 
-    - [```getReplacerPre1```](#getReplacerPre1) : <small>  [Zeile 445] : ```    getReplacerPre2 = getReplacerPre1(stichwort)``` </small>
+    - [`getReplacerPre1`](#getReplacerPre1) : <small>  [Zeile 445] : `    getReplacerPre2 = getReplacerPre1(stichwort)` </small>
 
 
-      - [```modifyReplacerIfSonderzeichen```](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : ```    Call modifyReplacerIfSonderzeichen(oErsatz)``` </small>
+      - [`modifyReplacerIfSonderzeichen`](#modifyReplacerIfSonderzeichen) : <small>  [Zeile 419] : `    Call modifyReplacerIfSonderzeichen(oErsatz)` </small>
 
 
 
         - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-      - [```modifyReplacerIfTaktwechsel```](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : ```    Call modifyReplacerIfTaktwechsel(oErsatz)``` </small>
+      - [`modifyReplacerIfTaktwechsel`](#modifyReplacerIfTaktwechsel) : <small>  [Zeile 422] : `    Call modifyReplacerIfTaktwechsel(oErsatz)` </small>
 
 
 
@@ -4969,38 +4969,38 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```getReplacerNote```](#getReplacerNote) : <small>  [Zeile 727] : ```                    oReplacer = getReplacerNote(stichwort)``` </small>
+- [`getReplacerNote`](#getReplacerNote) : <small>  [Zeile 727] : `                    oReplacer = getReplacerNote(stichwort)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```getReplacerCount```](#getReplacerCount) : <small>  [Zeile 729] : ```                    oReplacer = getReplacerCount(stichwort)``` </small>
+- [`getReplacerCount`](#getReplacerCount) : <small>  [Zeile 729] : `                    oReplacer = getReplacerCount(stichwort)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```getReplacerPost```](#getReplacerPost) : <small>  [Zeile 731] : ```                    oReplacer = getReplacerPost(stichwort)``` </small>
+- [`getReplacerPost`](#getReplacerPost) : <small>  [Zeile 731] : `                    oReplacer = getReplacerPost(stichwort)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```getReplacerEmpty```](#getReplacerEmpty) : <small>  [Zeile 733] : ```                    oReplacer = getReplacerEmpty()``` </small>
+- [`getReplacerEmpty`](#getReplacerEmpty) : <small>  [Zeile 733] : `                    oReplacer = getReplacerEmpty()` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```getFilePath```](#getFilePath) : <small>  [Zeile 742] : ```                pathImage = getFilePath(oReplacer.value)``` </small>
+- [`getFilePath`](#getFilePath) : <small>  [Zeile 742] : `                pathImage = getFilePath(oReplacer.value)` </small>
 
 
-    - [```getFilePath```](#getFilePath) : <small>  [Zeile 366] : ```    getFilePath = getFilePath(ERROR_FILENAME)``` </small>
+    - [`getFilePath`](#getFilePath) : <small>  [Zeile 366] : `    getFilePath = getFilePath(ERROR_FILENAME)` </small>
 
 
       - <small> *... recursivly calls itself under certain conditions ...* </small> 
@@ -5010,25 +5010,25 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
 
-- [```InsertImageFromFileToCell```](#InsertImageFromFileToCell) : <small>  [Zeile 744] : ```                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)``` </small>
+- [`InsertImageFromFileToCell`](#InsertImageFromFileToCell) : <small>  [Zeile 744] : `                Call InsertImageFromFileToCell(oSeite.excelZeilenNr, zielspalte, pathImage, oReplacer.cellFitTo)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```getTypeOfFollowingSeperatorLine```](#getTypeOfFollowingSeperatorLine) : <small>  [Zeile 757] : ```    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)``` </small>
+- [`getTypeOfFollowingSeperatorLine`](#getTypeOfFollowingSeperatorLine) : <small>  [Zeile 757] : `    followingLineStyle = getTypeOfFollowingSeperatorLine(zeileSteuertabelle, oSeite)` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```insertFrameLineBelow```](#insertFrameLineBelow) : <small>  [Zeile 762] : ```        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))``` </small>
+- [`insertFrameLineBelow`](#insertFrameLineBelow) : <small>  [Zeile 762] : `        Call insertFrameLineBelow(zeileSteuertabelle, oSeite, CBool(followingLineStyle - 1))` </small>
 
 
 
     - <small>*Keine weiteren Aufrufe zu anderen, hier dokumentierten Prozeduren.*</small>
 
-- [```SeitenformatNextPosition```](#SeitenformatNextPosition) : <small>  [Zeile 767] : ```    Call SeitenformatNextPosition(oSeite)``` </small>
+- [`SeitenformatNextPosition`](#SeitenformatNextPosition) : <small>  [Zeile 767] : `    Call SeitenformatNextPosition(oSeite)` </small>
 
 
 
@@ -5060,7 +5060,7 @@ Innehalb der Prozedur werden die folgenden, untergeordneten Prozeduren aufgerufe
 
 ---
 
-```
+`
 Private Function konvertiereZeile(zeileSteuertabelle As Integer, oSeite As Seitenformat) As Boolean
     ' # TODOC: ALT:
     ' Konvertiert eine Zeile des Todo-Tabellenblattes in eine Zeile des Ergebnis-Tabellenblattes.
@@ -5138,7 +5138,7 @@ Private Function konvertiereZeile(zeileSteuertabelle As Integer, oSeite As Seite
 
 End Function
 
-```
+`
 
 </details>
 
@@ -5189,9 +5189,9 @@ Die Prozedur wird in den folgenden, uebergeordneten Prozeduren aufgerufen:
 
 
 
-- [```identifyLastRow```](#identifyLastRow) : <small>  [Zeile 876] : ```    tempObj = newSeitenformat(readParameters:=False)``` </small>
+- [`identifyLastRow`](#identifyLastRow) : <small>  [Zeile 876] : `    tempObj = newSeitenformat(readParameters:=False)` </small>
 
-- [```addSeitenformat```](#addSeitenformat) : <small>  [Zeile 970] : ```    oFormat = newSeitenformat()``` </small>
+- [`addSeitenformat`](#addSeitenformat) : <small>  [Zeile 970] : `    oFormat = newSeitenformat()` </small>
 
 
 
@@ -5249,7 +5249,7 @@ Keine weiteren Aufrufe zu hier dokumentierten Prozeduren gefunden.
 
 ---
 
-```
+`
 Private Function newSeitenformat(Optional readParameters As Boolean = True) As Seitenformat
     '''''''''''''''''''''''''''''''''''''''''''''''''''''''
     ' Standard-Parameter aus TODO-Steuertabelle auslesen und Standardwerte parametrisieren.
@@ -5313,7 +5313,7 @@ Private Function newSeitenformat(Optional readParameters As Boolean = True) As S
 
 End Function
 
-```
+`
 
 </details>
 


### PR DESCRIPTION
This pull request addresses the following:
- Replaced all instances of triple backticks with single backticks for readability.
- This is to fix the problem raised in issue #19 